### PR TITLE
EZP-31651: Extracted search logic from adminUI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,7 @@
 | BC breaks?    | yes/no
 | Tests pass?   | yes/no
 | Doc needed?   | yes/no
-| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
+| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-search/blob/master/LICENSE)
 <!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->
 
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+| Question      | Answer
+| ------------- | ---
+| Tickets       |  [EZP-XXXXX](https://jira.ez.no/browse/EZP-XXXXX) <!-- URLs to JIRA issue(s) (or N/A) -->
+| Bug fix?      | yes/no
+| New feature?  | yes/no
+| BC breaks?    | yes/no
+| Tests pass?   | yes/no
+| Doc needed?   | yes/no
+| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
+<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->
+
+
+<!-- Replace this comment with Pull Request description -->
+
+
+#### Checklist:
+- [ ] Implement tests
+- [ ] Coding standards (`$ composer fix-cs`)

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/vendor
+/.php_cs.cache
+.phpunit.result.cache
+composer.lock

--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,12 @@
+<?php
+
+return EzSystems\EzPlatformCodeStyle\PhpCsFixer\Config::create()
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->in([
+                __DIR__ . '/src',
+                __DIR__ . '/tests'
+            ])
+            ->files()->name('*.php')
+    )
+;

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,6 @@ before_install:
   - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
   - TEST_TIMEZONES=("America/New_York" "Asia/Calcutta" "UTC")
   - TEST_TIMEZONE=${TEST_TIMEZONES["`shuf -i 0-2 -n 1`"]}
-    # Set composer credentials for private repositories
-  - if [ "$NETWORK_KEY" = "" ] ; then echo "Env variables are not available in pull requests from forks. Is your branch on the original repository?" && exit 1 ; fi
-  - travis_retry composer config http-basic.updates.ez.no $NETWORK_KEY $NETWORK_TOKEN
-  - travis_retry composer config github-oauth.github.com $GITHUB_TOKEN
 
 install:
   - travis_retry composer install --prefer-dist --no-interaction --no-suggest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,50 @@
+dist: trusty
+sudo: required
+
+language: php
+
+cache:
+  directories:
+    - "$HOME/.composer/cache/files"
+
+matrix:
+  fast_finish: true
+  include:
+    - name: PHP 7.3 Unit tests
+      php: 7.3
+      env: TEST_CONFIG="phpunit.xml"
+    - name: Code Style Check
+      php: 7.3
+      env: CHECK_CS=1
+
+branches:
+  only:
+    - master
+    - /^\d.\d+$/
+
+before_install:
+  - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - TEST_TIMEZONES=("America/New_York" "Asia/Calcutta" "UTC")
+  - TEST_TIMEZONE=${TEST_TIMEZONES["`shuf -i 0-2 -n 1`"]}
+    # Set composer credentials for private repositories
+  - if [ "$NETWORK_KEY" = "" ] ; then echo "Env variables are not available in pull requests from forks. Is your branch on the original repository?" && exit 1 ; fi
+  - travis_retry composer config http-basic.updates.ez.no $NETWORK_KEY $NETWORK_TOKEN
+  - travis_retry composer config github-oauth.github.com $GITHUB_TOKEN
+
+install:
+  - travis_retry composer install --prefer-dist --no-interaction --no-suggest
+
+script:
+  - if [ "$TEST_CONFIG" != "" ] ; then php -d date.timezone=$TEST_TIMEZONE -d memory_limit=-1 vendor/bin/phpunit -c $TEST_CONFIG ; fi
+  - if [ "$CHECK_CS" == "1" ] ; then ./vendor/bin/php-cs-fixer fix -v --dry-run --show-progress=estimating; fi
+
+notifications:
+  slack:
+    rooms:
+      - secure: yxi7DjE5l+OjWoxGN1LVMXDvnadg32AK51tOB/Ha8hOzeSopMu2pCZA9n2Ftw8e1oL5E9Y67jRlH0ywNgv1n4jiE/5y4SzYb2i5SyvcXO56alpc/qed6steRmowib6DFLGUtU3gk3XfpN6E0BVZD4mGAW/Y7+N8nckHGqVUvsab+1Vw8qPkHUMe3rjTIMMSDC2S40D88xUzsu3sMwPTuCw3Nlk/PJybcYQ9+YdlXtHGbwouSBSiUzCEEVF53qRJyXTA5Gm7tKqWBlpvMKg6Moxhp5Gu0SeFwd4EzviBwIwAANTL73NVjG0YT1Ygto8d4oOodpbg6xIuiTwK8NjI18MgiJoHBnpPqA4HCFRqIokGjqU0uVqbDQKoIjPcBvRyIpA6JvFOOwNQDJIqKwiUxabx8tU7R0wTe6UWRWdAP4FuF3pvdFoLKJMv3UmV90yqY4lFBXAJPg+V95H9ttFqVnPB+zDNrbSuZjci3gcwrRkW3KfnQmgNx/I++WZpkeZnrHX5p5MtpMCA5qlScqfXWU1MNethi86kZ2HrPuQGWRd8h9UDd4hjcDYUdOLYPjNZp0JPmqpc1sxE6AAYGe8SId/B0Ttpx3F2V1z4zF3alGzb8IMkdQb4bdYQhb+nQsmKkSegIRItsQv0ES1vN81Ff188Lts23ISLAODC7nZTRLdI=
+    on_success: change
+    on_failure: always
+    on_pull_requests: false
+
+git:
+  depth: 30

--- a/LICENSE
+++ b/LICENSE
@@ -1,306 +1,339 @@
-Copyright (C) 1999-2017 eZ Systems AS. All rights reserved.
-This source code is provided under the following license:
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
 
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc., <http://fsf.org/>
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-eZ Trial and Test License Agreement ("eZ TTL") Version 2.0
+                            Preamble
 
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
 
-IMPORTANT: Please read the following license agreement carefully.
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
 
-This license agreement is between eZ systems AS (Norwegian business
-registration no. 981 601 564), a Norwegian company ("Licensor" or "eZ"),
-and a test or trial user ("Licensee" or "you"). By installing all or any
-portion of the software (or authorizing any other person to do so), you
-accept the terms and conditions of this license. If you acquired the
-software without an opportunity to review this license and do not accept
-the license, you must: (a) not use the software and (b) return or delete
-the software, with your certification of deletion, within thirty (30)
-days of the acquire date.
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
 
-This license agreement is entered into in connection with Licensee's
-participation in testing a new version of Licensor software and is valid
-for 6 months from the date the software was acquired (downloaded).
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
 
-The parties hereby agree to the following software license terms:
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
 
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
 
-1. Definitions
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
 
-"Licensed Software" means the eZ Publish Enterprise Edition content
-management system or other software product downloaded, ordered or
-otherwise legally acquired (licensed) by Licensee from Licensor (or
-other party authorized by the Licensor) under these terms.
+  The precise terms and conditions for copying, distribution and
+modification follow.
 
-"Licensed Copy" means one sample of the Licensed Software.
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
 
-"Website" means up to three defined site access configurations (unique
-URLs) that may for instance consist of one site for public use, one site
-for internal use (such as an intranet) and one site for site
-administrator use, communicated an unlimited number of channels
-(such as traditional web, mobile).
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
 
-2. License grant
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
 
-2.1 You may
-Licensor grants you a limited, non-exclusive, time limited and
-non-transferable right to:
-(a) install and run the Licensed Copy on the agreed number of Websites
-for internal testing purposes;
-(b) make enhancements, patches, workarounds, bug fixes or other
-modifications (collectively "Licensee Modifications") to the Licensed
-Copy, solely for your internal testing of the Licensed Software, and
-(c) perform presentations based on the Licensed Software, including
-building and presenting sample solutions to your clients or potential
-clients.
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
 
-Since the license is free of charge, you are obliged to submit Licensee
-Modifications to eZ on a continuous basis to contribution@ez.no as
-contributions, see section 7.1. Such contribution must include a short
-note explaining the Licensee Modification.
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
 
-Licensee may make a reasonable number of copies of the Licensed Copy as
-required for backup and archival purposes only.
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
 
-2.2 You may not
-Licensee may use the Licensed Software only as expressly granted in
-section 2.1. Without limiting the foregoing, Licensee may not: (a) use
-or operate the Licensed Software for regular business use; (b) give,
-lease, license, sell, make available, or distribute any part of the
-Licensed Software or Licensee Modifications to any third party, except
-as otherwise expressly permitted herein; (c) use the Licensed Software
-to operate in or as a time-sharing, outsourcing, service bureau,
-application service provider, managed service provider environment or
-similar service directed towards and performed on behalf or for the
-benefit of a third party; (d) copy the Licensed Software onto any public
-or distributed network; or (e) change any rights notices which appear in
-the Licensed Software.
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
 
-3. Your responsibility
-Except as expressly set forth herein or in a separate written agreement,
-Licensee is the sole responsible for the installation of the Licensed
-Software, its operation, supervision, maintenance, management and
-related training and support. You are also the sole responsible for any
-related installation, maintenance and configuration of computer hardware
-used by the Licensed Software.
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
 
-4. Price
-You may use the Software free of charge.
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
 
-5. Audit rights
-During the term of this license and for a three (3) year period
-following its termination, Licensor may conduct periodic reviews of
-Licensee's records relating to its Licensed Software for the purpose of
-verifying Licensee's compliance with this license and any related
-agreements. During this three (3) year period, you are obliged to
-maintain complete and accurate books and other records related to
-software licensing and related payments. Licensor must exercise its
-right of audit upon no fewer than 15 days' prior notice. Licensee will
-provide Licensor with reasonable access and assistance for the audit,
-including reasonable use of available office equipment and space.
-Licensor shall upon request deliver to Licensee a copy of the results of
-any such audit.
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
 
-6. Termination
-Licensor may terminate this license immediately if you are in breach any
-of its provisions and such breach remains uncured 30 days after receipt
-of notice. In the event that you are or becomes liquidated, dissolved,
-bankrupt or insolvent, whether voluntarily or involuntarily, or is to
-take any action to be so declared, Licensor may terminate this license
-immediately. Upon cancellation or other termination of this license, for
-any reason, you must immediately destroy all copies of the Licensed
-Software, and confirm the destruction within  7 (seven) days. Sections 5
-through 11 shall survive the termination of this license for any reason.
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
 
-7. Intellectual property rights
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
 
-7.1 General
-Licensee agrees that the copyright and all other intellectual property
-and proprietary rights of whatever nature in the Licensed Software and
-related documentation are not by this license transferred to you. No
-trademarks of eZ may be used by you without Licensor's express written
-permission. If permission is grated, use must always take place in
-accordance with the applicable Licensor guidelines as they may be
-updated from time to time. For Licensee Modifications, you must, in the
-modified files and in a separate text file, clearly indicate that the
-Licensed Software contains modifications and state their dates.
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
 
-7.2 Contribution of Licensee Modifications
-To the extent that any contributed Licensee Modifications incorporates
-any element which is subject to any intellectual property right owned by
-Licensee, Licensee hereby grants to eZ an unrestricted, non-exclusive,
-perpetual, royalty-free, world-wide, irrevocable and fully transferable
-license to make, use, sell, offer for sale, reproduce, create
-derivatives of, publish, display, sublicense or otherwise practice such
-intellectual property right.
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
 
-Regarding any copyrights in Licensee Modifications:
-- You hereby assign to us joint ownership, and to the extent that such
-  assignment is or becomes invalid, ineffective or unenforceable, you
-  hereby grant to us a perpetual, irrevocable, non-exclusive, worldwide,
-  no-charge unrestricted license to exercise all rights under those
-  copyrights. This includes, at our option, the right to sublicense
-  these same rights to third parties through multiple levels of
-  sub-licensees or other licensing arrangements;
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
 
-- You agree that each of us can do all things in relation to Licensee
-  Modifications as if each of us were sole and independent copyright
-  holders. If one of us makes a derivative work the Licensee
-  Modifications, the one who makes the derivative work (or has it made)
-  will be the sole owner of that derivative work, hereunder make, have
-  made, use, license, offer to license, import, and otherwise transfer
-  your contribution in whole or in part, whether at a charge or at
-  no-charge;
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
 
-- You agree that neither of us have any duty to consult with, obtain the
-  consent of, pay or render accounts to the other for any use or
-  distribution of the material.
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
 
-With respect to the Licensee Modifications, you represent that:
-- it is an original work by you and that you can legally grant the
-  rights set out in these terms;
-- it does not to the best of your knowledge violate any third party's
-  copyrights, trademarks, patents or other intellectual property rights.
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
 
-8. Disclaimer of warranties
-The Licensed Software is licensed "as is," without any warranties
-whatsoever. Licensor expressly disclaims, and licensee expressly waives,
-all warranties, whether express or implied, including warranties of
-merchantability, fitness for a particular purpose, non-infringement,
-system integration, non-interference and accuracy of informational
-content. Licensor does not warrant that the licensed software will meet
-licensee's requirements or that the operation of the licensed software
-will be uninterrupted or error-free, or that errors will be corrected.
-The entire risk of the licensed software's quality and performance is
-with licensee.
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
 
-9. Indemnification
-Licensee agrees to indemnify and hold Licensor harmless against any
-damage or loss (including reasonable attorneys' fees) related to any
-claim based upon: (a) use of the Licensed Software in a manner
-prohibited under this license or in a manner for which the Licensed
-Software was not designed; (b) Licensee Modifications or changes made by
-Licensee to the Licensed Software (where use of unmodified Licensed
-Software would not infringe); or (c) changes made, or actions taken, by
-Licensor upon Licensee's direct instructions.
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
 
-10. Limitation of liability
-To the extent permitted by applicable law, licensor shall have no
-liability with respect to its obligations under this license or
-otherwise for direct, consequential, exemplary, special, indirect,
-incidental or punitive damages, including any lost profits or lost
-savings (whether resulting from impaired or lost data, software or
-computer failure or any other cause), even if it has been advised of the
-possibility of such damages.
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
 
-This limitation of liability applies to any default, including breach of
-contract, breach of warranty, negligence, misrepresentations and other
-torts. The parties agree that the remedies and limitations herein
-allocate the risks between the parties as authorized by applicable laws.
-The license fee (non) is set in reliance upon this allocation of risk
-and the exclusion of certain damages as set forth in this license.
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
 
-11. Miscellaneous
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
 
-11.1 Interpretation
-Failure by Licensor to exercise any right or remedy does not signify
-acceptance of the event giving rise to such right or remedy, or loss of
-such right. No claim arising out of this License may be brought by you
-more than one year after the cause of the claim arose.
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
 
-If any part of this license is held by a court of competent jurisdiction
-to be illegal or unenforceable, the validity or enforceability of the
-remainder of this License shall not be affected and such provision shall
-be deemed modified to the minimum extent necessary to make such
-provision consistent with applicable law. In its modified form, such
-provision shall be enforceable and enforced.
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
 
-11.2 Termination for patent action
-This license shall terminate automatically and you may no longer
-exercise any of the rights granted to you by this license as of the date
-you commence an action, including a cross-claim or counterclaim, against
-eZ, an eZ partner or other licensee of eZ software alleging that the
-Software infringes a patent.
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
 
-11.3 Assignment
-Without the prior written consent of Licensor, you may not assign,
-sublicense or otherwise transfer this license or its rights or
-obligations under this license to any person or party, whether by
-operation of law or otherwise. Any attempt by you to assign this license
-without Licensor's prior written consent is void and will terminate the
-license without further notice.
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
 
-11.4 Governing law
-This License shall be deemed to have been executed in Norway and shall
-be governed by the laws of Norway, without regard to any conflict of law
-provisions.
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
 
-11.5 Disputes and legal venue
-The parties shall first attempt to resolve any disputes, controversies
-or claims (collectively "Dispute") arising out of or relating to this
-license through amicable discussions and negotiations.
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
 
-If a Dispute cannot be resolved amicably between the parties, such
-Dispute shall be referred to Oslo City Court as mandatory legal venue.
-However, if you are located in a country that does not have a bilateral
-or multilateral ruling enforcement treaty with Norway, the Dispute shall
-be referred to and finally determined by arbitration administered by the
-World Intellectual Property Organization (WIPO) Arbitration and
-Mediation Centre in accordance with the WIPO Arbitration Rules.
+                            NO WARRANTY
 
-The place of arbitration shall be in Oslo, Norway. The arbitrator - of
-which there shall be only one - shall be bound by the provisions of this
-license and base the award on Norwegian substantive law and judicial
-precedent. The parties agree that the arbitrator shall have the power to
-decide all matters, including arbitrability, and to award any remedies,
-including attorneys' fees, costs and equitable relief, available under
-applicable law. Either party may enforce any judgment rendered by the
-arbitrator in any court of competent jurisdiction. The parties further
-agree and acknowledge that arbitration shall be the sole and final
-remedy for any dispute between the parties. All proceedings and
-documents shall remain strictly confidential.
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
 
-In no event shall the United Nations Convention on Contracts for the
-International Sale of Goods apply to, or govern, this License.
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
 
-11.6 Notices
-Any notice under this license shall be delivered and addressed to
-Licensee at the address provided to Licensor (or authorized
-representative) at the time of order, and to Licensor at
+                     END OF TERMS AND CONDITIONS
 
-Attn: Software Licensing Dept/CLA,
-eZ Systems AS,
-Klostergata 30,
-N-3732 Skien,
-Norway
+            How to Apply These Terms to Your New Programs
 
-Notices are deemed received by any party: (a) on the day given, if
-personally delivered or if sent by confirmed facsimile transmission,
-receipt verified; (b) on the third day after deposit, if mailed by
-certified, first class, postage prepaid, return receipt requested mail,
-or by reputable, expedited overnight courier; or (c) on the fifth day
-after deposit, if sent by reputable, expedited international courier.
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
 
-Either party may change its address for notice purposes upon notice in
-accordance with this section.
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
 
-11.7 Export law assurances
-Licensee is responsible for complying with any applicable local laws,
-including but not limited to export and import regulations.
+    {description}
+    Copyright (C) {year}  {fullname}
 
-11.8 Entire agreement
-This license comprises the entire agreement, and supersedes and merges
-all prior proposals, understandings and agreements, oral and written,
-between the parties relating to the subject matter of this license.
-Licensor's acceptance of any document shall not be construed as an
-acceptance of provisions which are in any way in conflict or
-inconsistent with, or in addition to, this license, unless such terms
-are separately and specifically accepted in writing by an authorized
-officer of Licensor.
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
 
-11.9 Update of terms
-The Licensor may from time to time issue new versions of this license.
-Unless you within 30 days from when you were first made aware or should
-have become aware of the new license has not made reservations directed
-at Licensor in writing, such new version of the license shall be deemed
-as accepted by you.
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
 
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  {signature of Ty Coon}, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,306 @@
+Copyright (C) 1999-2017 eZ Systems AS. All rights reserved.
+This source code is provided under the following license:
+
+
+eZ Trial and Test License Agreement ("eZ TTL") Version 2.0
+
+
+IMPORTANT: Please read the following license agreement carefully.
+
+This license agreement is between eZ systems AS (Norwegian business
+registration no. 981 601 564), a Norwegian company ("Licensor" or "eZ"),
+and a test or trial user ("Licensee" or "you"). By installing all or any
+portion of the software (or authorizing any other person to do so), you
+accept the terms and conditions of this license. If you acquired the
+software without an opportunity to review this license and do not accept
+the license, you must: (a) not use the software and (b) return or delete
+the software, with your certification of deletion, within thirty (30)
+days of the acquire date.
+
+This license agreement is entered into in connection with Licensee's
+participation in testing a new version of Licensor software and is valid
+for 6 months from the date the software was acquired (downloaded).
+
+The parties hereby agree to the following software license terms:
+
+
+1. Definitions
+
+"Licensed Software" means the eZ Publish Enterprise Edition content
+management system or other software product downloaded, ordered or
+otherwise legally acquired (licensed) by Licensee from Licensor (or
+other party authorized by the Licensor) under these terms.
+
+"Licensed Copy" means one sample of the Licensed Software.
+
+"Website" means up to three defined site access configurations (unique
+URLs) that may for instance consist of one site for public use, one site
+for internal use (such as an intranet) and one site for site
+administrator use, communicated an unlimited number of channels
+(such as traditional web, mobile).
+
+2. License grant
+
+2.1 You may
+Licensor grants you a limited, non-exclusive, time limited and
+non-transferable right to:
+(a) install and run the Licensed Copy on the agreed number of Websites
+for internal testing purposes;
+(b) make enhancements, patches, workarounds, bug fixes or other
+modifications (collectively "Licensee Modifications") to the Licensed
+Copy, solely for your internal testing of the Licensed Software, and
+(c) perform presentations based on the Licensed Software, including
+building and presenting sample solutions to your clients or potential
+clients.
+
+Since the license is free of charge, you are obliged to submit Licensee
+Modifications to eZ on a continuous basis to contribution@ez.no as
+contributions, see section 7.1. Such contribution must include a short
+note explaining the Licensee Modification.
+
+Licensee may make a reasonable number of copies of the Licensed Copy as
+required for backup and archival purposes only.
+
+2.2 You may not
+Licensee may use the Licensed Software only as expressly granted in
+section 2.1. Without limiting the foregoing, Licensee may not: (a) use
+or operate the Licensed Software for regular business use; (b) give,
+lease, license, sell, make available, or distribute any part of the
+Licensed Software or Licensee Modifications to any third party, except
+as otherwise expressly permitted herein; (c) use the Licensed Software
+to operate in or as a time-sharing, outsourcing, service bureau,
+application service provider, managed service provider environment or
+similar service directed towards and performed on behalf or for the
+benefit of a third party; (d) copy the Licensed Software onto any public
+or distributed network; or (e) change any rights notices which appear in
+the Licensed Software.
+
+3. Your responsibility
+Except as expressly set forth herein or in a separate written agreement,
+Licensee is the sole responsible for the installation of the Licensed
+Software, its operation, supervision, maintenance, management and
+related training and support. You are also the sole responsible for any
+related installation, maintenance and configuration of computer hardware
+used by the Licensed Software.
+
+4. Price
+You may use the Software free of charge.
+
+5. Audit rights
+During the term of this license and for a three (3) year period
+following its termination, Licensor may conduct periodic reviews of
+Licensee's records relating to its Licensed Software for the purpose of
+verifying Licensee's compliance with this license and any related
+agreements. During this three (3) year period, you are obliged to
+maintain complete and accurate books and other records related to
+software licensing and related payments. Licensor must exercise its
+right of audit upon no fewer than 15 days' prior notice. Licensee will
+provide Licensor with reasonable access and assistance for the audit,
+including reasonable use of available office equipment and space.
+Licensor shall upon request deliver to Licensee a copy of the results of
+any such audit.
+
+6. Termination
+Licensor may terminate this license immediately if you are in breach any
+of its provisions and such breach remains uncured 30 days after receipt
+of notice. In the event that you are or becomes liquidated, dissolved,
+bankrupt or insolvent, whether voluntarily or involuntarily, or is to
+take any action to be so declared, Licensor may terminate this license
+immediately. Upon cancellation or other termination of this license, for
+any reason, you must immediately destroy all copies of the Licensed
+Software, and confirm the destruction within  7 (seven) days. Sections 5
+through 11 shall survive the termination of this license for any reason.
+
+7. Intellectual property rights
+
+7.1 General
+Licensee agrees that the copyright and all other intellectual property
+and proprietary rights of whatever nature in the Licensed Software and
+related documentation are not by this license transferred to you. No
+trademarks of eZ may be used by you without Licensor's express written
+permission. If permission is grated, use must always take place in
+accordance with the applicable Licensor guidelines as they may be
+updated from time to time. For Licensee Modifications, you must, in the
+modified files and in a separate text file, clearly indicate that the
+Licensed Software contains modifications and state their dates.
+
+7.2 Contribution of Licensee Modifications
+To the extent that any contributed Licensee Modifications incorporates
+any element which is subject to any intellectual property right owned by
+Licensee, Licensee hereby grants to eZ an unrestricted, non-exclusive,
+perpetual, royalty-free, world-wide, irrevocable and fully transferable
+license to make, use, sell, offer for sale, reproduce, create
+derivatives of, publish, display, sublicense or otherwise practice such
+intellectual property right.
+
+Regarding any copyrights in Licensee Modifications:
+- You hereby assign to us joint ownership, and to the extent that such
+  assignment is or becomes invalid, ineffective or unenforceable, you
+  hereby grant to us a perpetual, irrevocable, non-exclusive, worldwide,
+  no-charge unrestricted license to exercise all rights under those
+  copyrights. This includes, at our option, the right to sublicense
+  these same rights to third parties through multiple levels of
+  sub-licensees or other licensing arrangements;
+
+- You agree that each of us can do all things in relation to Licensee
+  Modifications as if each of us were sole and independent copyright
+  holders. If one of us makes a derivative work the Licensee
+  Modifications, the one who makes the derivative work (or has it made)
+  will be the sole owner of that derivative work, hereunder make, have
+  made, use, license, offer to license, import, and otherwise transfer
+  your contribution in whole or in part, whether at a charge or at
+  no-charge;
+
+- You agree that neither of us have any duty to consult with, obtain the
+  consent of, pay or render accounts to the other for any use or
+  distribution of the material.
+
+With respect to the Licensee Modifications, you represent that:
+- it is an original work by you and that you can legally grant the
+  rights set out in these terms;
+- it does not to the best of your knowledge violate any third party's
+  copyrights, trademarks, patents or other intellectual property rights.
+
+8. Disclaimer of warranties
+The Licensed Software is licensed "as is," without any warranties
+whatsoever. Licensor expressly disclaims, and licensee expressly waives,
+all warranties, whether express or implied, including warranties of
+merchantability, fitness for a particular purpose, non-infringement,
+system integration, non-interference and accuracy of informational
+content. Licensor does not warrant that the licensed software will meet
+licensee's requirements or that the operation of the licensed software
+will be uninterrupted or error-free, or that errors will be corrected.
+The entire risk of the licensed software's quality and performance is
+with licensee.
+
+9. Indemnification
+Licensee agrees to indemnify and hold Licensor harmless against any
+damage or loss (including reasonable attorneys' fees) related to any
+claim based upon: (a) use of the Licensed Software in a manner
+prohibited under this license or in a manner for which the Licensed
+Software was not designed; (b) Licensee Modifications or changes made by
+Licensee to the Licensed Software (where use of unmodified Licensed
+Software would not infringe); or (c) changes made, or actions taken, by
+Licensor upon Licensee's direct instructions.
+
+10. Limitation of liability
+To the extent permitted by applicable law, licensor shall have no
+liability with respect to its obligations under this license or
+otherwise for direct, consequential, exemplary, special, indirect,
+incidental or punitive damages, including any lost profits or lost
+savings (whether resulting from impaired or lost data, software or
+computer failure or any other cause), even if it has been advised of the
+possibility of such damages.
+
+This limitation of liability applies to any default, including breach of
+contract, breach of warranty, negligence, misrepresentations and other
+torts. The parties agree that the remedies and limitations herein
+allocate the risks between the parties as authorized by applicable laws.
+The license fee (non) is set in reliance upon this allocation of risk
+and the exclusion of certain damages as set forth in this license.
+
+11. Miscellaneous
+
+11.1 Interpretation
+Failure by Licensor to exercise any right or remedy does not signify
+acceptance of the event giving rise to such right or remedy, or loss of
+such right. No claim arising out of this License may be brought by you
+more than one year after the cause of the claim arose.
+
+If any part of this license is held by a court of competent jurisdiction
+to be illegal or unenforceable, the validity or enforceability of the
+remainder of this License shall not be affected and such provision shall
+be deemed modified to the minimum extent necessary to make such
+provision consistent with applicable law. In its modified form, such
+provision shall be enforceable and enforced.
+
+11.2 Termination for patent action
+This license shall terminate automatically and you may no longer
+exercise any of the rights granted to you by this license as of the date
+you commence an action, including a cross-claim or counterclaim, against
+eZ, an eZ partner or other licensee of eZ software alleging that the
+Software infringes a patent.
+
+11.3 Assignment
+Without the prior written consent of Licensor, you may not assign,
+sublicense or otherwise transfer this license or its rights or
+obligations under this license to any person or party, whether by
+operation of law or otherwise. Any attempt by you to assign this license
+without Licensor's prior written consent is void and will terminate the
+license without further notice.
+
+11.4 Governing law
+This License shall be deemed to have been executed in Norway and shall
+be governed by the laws of Norway, without regard to any conflict of law
+provisions.
+
+11.5 Disputes and legal venue
+The parties shall first attempt to resolve any disputes, controversies
+or claims (collectively "Dispute") arising out of or relating to this
+license through amicable discussions and negotiations.
+
+If a Dispute cannot be resolved amicably between the parties, such
+Dispute shall be referred to Oslo City Court as mandatory legal venue.
+However, if you are located in a country that does not have a bilateral
+or multilateral ruling enforcement treaty with Norway, the Dispute shall
+be referred to and finally determined by arbitration administered by the
+World Intellectual Property Organization (WIPO) Arbitration and
+Mediation Centre in accordance with the WIPO Arbitration Rules.
+
+The place of arbitration shall be in Oslo, Norway. The arbitrator - of
+which there shall be only one - shall be bound by the provisions of this
+license and base the award on Norwegian substantive law and judicial
+precedent. The parties agree that the arbitrator shall have the power to
+decide all matters, including arbitrability, and to award any remedies,
+including attorneys' fees, costs and equitable relief, available under
+applicable law. Either party may enforce any judgment rendered by the
+arbitrator in any court of competent jurisdiction. The parties further
+agree and acknowledge that arbitration shall be the sole and final
+remedy for any dispute between the parties. All proceedings and
+documents shall remain strictly confidential.
+
+In no event shall the United Nations Convention on Contracts for the
+International Sale of Goods apply to, or govern, this License.
+
+11.6 Notices
+Any notice under this license shall be delivered and addressed to
+Licensee at the address provided to Licensor (or authorized
+representative) at the time of order, and to Licensor at
+
+Attn: Software Licensing Dept/CLA,
+eZ Systems AS,
+Klostergata 30,
+N-3732 Skien,
+Norway
+
+Notices are deemed received by any party: (a) on the day given, if
+personally delivered or if sent by confirmed facsimile transmission,
+receipt verified; (b) on the third day after deposit, if mailed by
+certified, first class, postage prepaid, return receipt requested mail,
+or by reputable, expedited overnight courier; or (c) on the fifth day
+after deposit, if sent by reputable, expedited international courier.
+
+Either party may change its address for notice purposes upon notice in
+accordance with this section.
+
+11.7 Export law assurances
+Licensee is responsible for complying with any applicable local laws,
+including but not limited to export and import regulations.
+
+11.8 Entire agreement
+This license comprises the entire agreement, and supersedes and merges
+all prior proposals, understandings and agreements, oral and written,
+between the parties relating to the subject matter of this license.
+Licensor's acceptance of any document shall not be construed as an
+acceptance of provisions which are in any way in conflict or
+inconsistent with, or in addition to, this license, unless such terms
+are separately and specifically accepted in writing by an authorized
+officer of Licensor.
+
+11.9 Update of terms
+The Licensor may from time to time issue new versions of this license.
+Unless you within 30 days from when you were first made aware or should
+have become aware of the new license has not made reservations directed
+at Licensor in writing, such new version of the license shall be deemed
+as accepted by you.
+

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,14 @@
   },
   "require": {
     "php": "^7.3",
+    "ezsystems/ezplatform-kernel": "^1.0@dev",
     "symfony/dependency-injection": "^5.0",
     "symfony/http-kernel": "^5.0",
     "symfony/http-foundation": "^5.0",
     "symfony/config": "^5.0",
     "symfony/form": "^5.0",
-    "symfony/event-dispatcher": "^5.0"
+    "symfony/event-dispatcher": "^5.0",
+    "pagerfanta/pagerfanta": "^2.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5",

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,34 @@
+{
+  "name": "ezsystems/ezplatform-search",
+  "description": "Platform Search bundle",
+  "type": "ezplatform-bundle",
+  "license": "TTL-2.0",
+  "autoload": {
+    "psr-4": {
+      "Ibexa\\Platform\\Bundle\\SearchBundle\\": "src/bundle/",
+      "Ibexa\\Platform\\Search": "src/lib/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Ibexa\\Platform\\Bundle\\SearchBundle\\Tests\\": "tests/bundle/",
+      "Ibexa\\Platform\\Search\\Tests\\": "tests/lib/"
+    }
+  },
+  "require": {
+    "php": "^7.3"
+  },
+  "require-dev": {
+    "phpunit/phpunit": "^8.5",
+    "friendsofphp/php-cs-fixer": "^2.16",
+    "ezsystems/ezplatform-code-style": "^0.1",
+  },
+  "scripts": {
+    "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "1.0.x-dev"
+    }
+  }
+}

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "autoload": {
     "psr-4": {
       "Ibexa\\Platform\\Bundle\\SearchBundle\\": "src/bundle/",
-      "Ibexa\\Platform\\Search": "src/lib/"
+      "Ibexa\\Platform\\Search\\": "src/lib/"
     }
   },
   "autoload-dev": {
@@ -21,7 +21,7 @@
   "require-dev": {
     "phpunit/phpunit": "^8.5",
     "friendsofphp/php-cs-fixer": "^2.16",
-    "ezsystems/ezplatform-code-style": "^0.1",
+    "ezsystems/ezplatform-code-style": "^0.1"
   },
   "scripts": {
     "fix-cs": "@php ./vendor/bin/php-cs-fixer fix -v --show-progress=estimating"

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,13 @@
     }
   },
   "require": {
-    "php": "^7.3"
+    "php": "^7.3",
+    "symfony/dependency-injection": "^5.0",
+    "symfony/http-kernel": "^5.0",
+    "symfony/http-foundation": "^5.0",
+    "symfony/config": "^5.0",
+    "symfony/form": "^5.0",
+    "symfony/event-dispatcher": "^5.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.5",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,26 @@
+<phpunit
+        backupGlobals="false"
+        backupStaticAttributes="false"
+        bootstrap="vendor/autoload.php"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
+        colors="true">
+    <testsuites>
+        <testsuite name="Bundle Tests">
+            <directory>tests/bundle/</directory>
+        </testsuite>
+        <testsuite name="Lib Tests">
+            <directory>tests/lib/</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory>src</directory>
+            <exclude>
+                <directory>tests/bundle/</directory>
+                <directory>tests/lib/</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/bundle/Controller/SearchController.php
+++ b/src/bundle/Controller/SearchController.php
@@ -1,0 +1,167 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\Platform\Bundle\SearchBundle\Controller;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\SectionService;
+use eZ\Publish\API\Repository\Values\Content\Language;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\Pagination\Pagerfanta\ContentSearchHitAdapter;
+use eZ\Publish\Core\QueryType\QueryType;
+use EzSystems\EzPlatformAdminUi\Form\Data\Search\SearchData;
+use EzSystems\EzPlatformAdminUi\Form\Type\Search\SearchType;
+use EzSystems\EzPlatformAdminUi\Search\PagerSearchContentToDataMapper;
+use Pagerfanta\Pagerfanta;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Form\FormFactory;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SearchController extends AbstractController
+{
+    /** @var \eZ\Publish\API\Repository\SearchService */
+    private $searchService;
+
+    /** @var \EzSystems\EzPlatformAdminUi\Search\PagerSearchContentToDataMapper */
+    private $pagerSearchContentToDataMapper;
+
+    private $formFactory;
+
+    /** @var \eZ\Publish\API\Repository\SectionService */
+    private $sectionService;
+
+    /** @var \eZ\Publish\API\Repository\ContentTypeService */
+    private $contentTypeService;
+
+    /** @var \EzSystems\EzPlatformAdminUi\QueryType\SearchQueryType */
+    private $searchQueryType;
+
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    private $configResolver;
+
+    public function __construct(
+        SearchService $searchService,
+        PagerSearchContentToDataMapper $pagerSearchContentToDataMapper,
+        FormFactory $formFactory,
+        SectionService $sectionService,
+        ContentTypeService $contentTypeService,
+        QueryType $searchQueryType,
+        ConfigResolverInterface $configResolver
+    ) {
+        $this->searchService = $searchService;
+        $this->pagerSearchContentToDataMapper = $pagerSearchContentToDataMapper;
+        $this->formFactory = $formFactory;
+        $this->sectionService = $sectionService;
+        $this->contentTypeService = $contentTypeService;
+        $this->searchQueryType = $searchQueryType;
+        $this->configResolver = $configResolver;
+    }
+
+    /**
+     * Renders the simple search form and search results.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \InvalidArgumentException
+     */
+    public function searchAction(Request $request): Response
+    {
+        $search = $request->query->get('search');
+        $limit = $search['limit'] ?? $this->configResolver->getParameter('pagination.search_limit');
+        $page = $search['page'] ?? 1;
+        $query = $search['query'] ?? '';
+        $section = null;
+        $creator = null;
+        $contentTypes = [];
+        $lastModified = $search['last_modified'] ?? [];
+        $created = $search['created'] ?? [];
+        $subtree = $search['subtree'] ?? null;
+        $searchLanguage = null;
+
+        if (!empty($search['section'])) {
+            $section = $this->sectionService->loadSection($search['section']);
+        }
+        if (!empty($search['content_types']) && \is_array($search['content_types'])) {
+            foreach ($search['content_types'] as $identifier) {
+                $contentTypes[] = $this->contentTypeService->loadContentTypeByIdentifier($identifier);
+            }
+        }
+
+        $form = $this->formFactory->create(
+            SearchType::class,
+            new SearchData(
+                $limit,
+                $page,
+                $query,
+                $section,
+                $contentTypes,
+                $lastModified,
+                $created,
+                $creator,
+                $subtree,
+                $searchLanguage
+            ),
+            [
+                'method' => Request::METHOD_GET,
+                'csrf_protection' => false,
+            ]
+        );
+
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $data = $form->getData();
+            $queryString = $data->getQuery();
+            $searchLanguageCode = ($data->getSearchLanguage() instanceof Language)
+                ? $data->getSearchLanguage()->languageCode
+                : null;
+            $languageFilter = $this->getSearchLanguageFilter($searchLanguageCode, $queryString);
+
+            $pagerfanta = new Pagerfanta(
+                new ContentSearchHitAdapter(
+                    $this->searchQueryType->getQuery(['search_data' => $data]),
+                    $this->searchService,
+                    $languageFilter
+                )
+            );
+            $pagerfanta->setMaxPerPage($data->getLimit());
+            $pagerfanta->setCurrentPage(min($data->getPage(), $pagerfanta->getNbPages()));
+
+//            $editForm = $this->formFactory->contentEdit(
+//                new ContentEditData()
+//            );
+
+            return $this->render('@ezdesign/ui/search/index.html.twig', [
+                'results' => $this->pagerSearchContentToDataMapper->map($pagerfanta),
+                'form' => $form->createView(),
+                'pager' => $pagerfanta,
+//                'form_edit' => $editForm->createView(),
+                'user_content_type_identifier' => $this->configResolver->getParameter('user_content_type_identifier'),
+            ]);
+        }
+
+        return $this->render('@ezdesign/ui/search/index.html.twig', [
+            'form' => $form->createView(),
+            'user_content_type_identifier' => $this->configResolver->getParameter('user_content_type_identifier'),
+        ]);
+    }
+
+    private function getSearchLanguageFilter(?string $languageCode, ?string $queryString): array
+    {
+        $filter = [
+            'languages' => !empty($languageCode) ? [$languageCode] : [],
+            'useAlwaysAvailable' => true,
+        ];
+
+        if (!empty($queryString)) {
+            $filter['excludeTranslationsFromAlwaysAvailable'] = false;
+        }
+
+        return $filter;
+    }
+}

--- a/src/bundle/DependencyInjection/Compiler/ViewBuilderRegistryPass.php
+++ b/src/bundle/DependencyInjection/Compiler/ViewBuilderRegistryPass.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Platform\Bundle\SearchBundle\DependencyInjection\Compiler;
+
+use Ibexa\Platform\Search\View\SearchListViewBuilder;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ViewBuilderRegistryPass implements CompilerPassInterface
+{
+    public const VIEW_BUILDER_REGISTRY = 'ezpublish.view_builder.registry';
+    public const VIEW_BUILDER_UPDATE_VIEW = SearchListViewBuilder::class;
+
+    public function process(ContainerBuilder $container): void
+    {
+        if (!$container->hasDefinition(self::VIEW_BUILDER_REGISTRY)) {
+            return;
+        }
+
+        if (!$container->hasDefinition(self::VIEW_BUILDER_UPDATE_VIEW)) {
+            return;
+        }
+
+        $registry = $container->findDefinition(self::VIEW_BUILDER_REGISTRY);
+        $registry->addMethodCall('addToRegistry', [
+            [$container->getDefinition(self::VIEW_BUILDER_UPDATE_VIEW)],
+        ]);
+    }
+}

--- a/src/bundle/DependencyInjection/Configuration/Parser/Search.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Search.php
@@ -37,7 +37,7 @@ class Search extends AbstractParser
             ->end();
     }
 
-    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer): void
     {
         if (empty($scopeSettings['search'])) {
             return;

--- a/src/bundle/DependencyInjection/Configuration/Parser/Search.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/Search.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Platform\Bundle\SearchBundle\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\AbstractParser;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware\ContextualizerInterface;
+use Symfony\Component\Config\Definition\Builder\NodeBuilder;
+
+class Search extends AbstractParser
+{
+    /**
+     * Adds semantic configuration definition.
+     *
+     * @param \Symfony\Component\Config\Definition\Builder\NodeBuilder $nodeBuilder Node just under ezpublish.system.<siteaccess>
+     */
+    public function addSemanticConfig(NodeBuilder $nodeBuilder)
+    {
+        $nodeBuilder
+            ->arrayNode('search')
+                ->info('Search configuration')
+                ->children()
+                    ->arrayNode('pagination')
+                        ->info('Pagination related configuration')
+                        ->children()
+                            ->integerNode('limit')
+                                ->info('Number of results per page')
+                            ->end()
+                        ->end()
+                    ->end()
+                ->end()
+            ->end();
+    }
+
+    public function mapConfig(array &$scopeSettings, $currentScope, ContextualizerInterface $contextualizer)
+    {
+        if (empty($scopeSettings['search'])) {
+            return;
+        }
+
+        $settings = $scopeSettings['search'];
+
+        if (!empty($settings['pagination']['limit'])) {
+            $contextualizer->setContextualParameter(
+                'search.pagination.limit',
+                $currentScope,
+                $settings['pagination']['limit']);
+        }
+    }
+}

--- a/src/bundle/DependencyInjection/Configuration/Parser/SearchListView.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/SearchListView.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Platform\Bundle\SearchBundle\DependencyInjection\Configuration\Parser;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\View;
+
+class SearchListView extends View
+{
+    public const NODE_KEY = 'search_list_view';
+    public const INFO = 'Template for displaying main search form and results';
+}

--- a/src/bundle/DependencyInjection/PlatformSearchExtension.php
+++ b/src/bundle/DependencyInjection/PlatformSearchExtension.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Platform\Bundle\SearchBundle\DependencyInjection;
+
+use EzSystems\EzPlatformVersionComparisonBundle\DependencyInjection\Configuration;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+
+class PlatformSearchExtension extends Extension
+{
+    public function load(array $configs, ContainerBuilder $container)
+    {
+        $configuration = new Configuration();
+        $this->processConfiguration($configuration, $configs);
+
+        $loader = new YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader->load('services.yaml');
+    }
+}

--- a/src/bundle/PlatformSearchBundle.php
+++ b/src/bundle/PlatformSearchBundle.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\Platform\Bundle\SearchBundle;
+
+use EzSystems\EzPlatformRestBundle\DependencyInjection\Compiler;
+use EzSystems\EzPlatformRestBundle\DependencyInjection\Security\RestSessionBasedFactory;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class PlatformSearchBundle extends Bundle
+{
+}

--- a/src/bundle/PlatformSearchBundle.php
+++ b/src/bundle/PlatformSearchBundle.php
@@ -6,11 +6,23 @@
  */
 namespace Ibexa\Platform\Bundle\SearchBundle;
 
-use EzSystems\EzPlatformRestBundle\DependencyInjection\Compiler;
-use EzSystems\EzPlatformRestBundle\DependencyInjection\Security\RestSessionBasedFactory;
+use Ibexa\Platform\Bundle\SearchBundle\DependencyInjection\Compiler\ViewBuilderRegistryPass;
+use Ibexa\Platform\Bundle\SearchBundle\DependencyInjection\Configuration\Parser\Search;
+use Ibexa\Platform\Bundle\SearchBundle\DependencyInjection\Configuration\Parser\SearchListView;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class PlatformSearchBundle extends Bundle
 {
+    public function build(ContainerBuilder $container)
+    {
+        /** @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension $core */
+        $core = $container->getExtension('ezpublish');
+
+        $core->addDefaultSettings(__DIR__ . '/Resources/config', ['default_settings.yaml']);
+        $core->addConfigParser(new Search());
+        $core->addConfigParser(new SearchListView());
+
+        $container->addCompilerPass(new ViewBuilderRegistryPass());
+    }
 }

--- a/src/bundle/Resources/config/default_settings.yaml
+++ b/src/bundle/Resources/config/default_settings.yaml
@@ -1,0 +1,9 @@
+parameters:
+    ezsettings.site.pagination.search_limit: 10
+    ezsettings.site.user_content_type_identifier: ['user']
+
+    ezsettings.site.search_list_view:
+        full:
+            default:
+                template: "@@ezdesign/search/index.html.twig"
+                match: []

--- a/src/bundle/Resources/config/routing.yaml
+++ b/src/bundle/Resources/config/routing.yaml
@@ -1,0 +1,5 @@
+ezplatform.search:
+    path: /search
+    methods: ['GET']
+    defaults:
+      _controller: 'Ibexa\Platform\Bundle\SearchBundle\Controller\SearchController::searchAction'

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -4,12 +4,35 @@ services:
       autowire: true
       public: false
 
-      EzSystems\EzPlatformAdminUiBundle\Controller\SearchController:
-          parent: Symfony\Bundle\FrameworkBundle\Controller\AbstractController
-          autowire: true
-          lazy: true
-          arguments:
-              $searchQueryType: '@EzSystems\EzPlatformAdminUi\QueryType\SearchQueryType'
-              $configResolver: '@ezpublish.config.resolver'
-          tags:
-              - controller.service_arguments
+  Ibexa\Platform\Bundle\SearchBundle\Controller\SearchController:
+      arguments:
+          $searchQueryType: '@EzSystems\EzPlatformAdminUi\QueryType\SearchQueryType'
+          $configResolver: '@ezpublish.config.resolver'
+      tags:
+          - controller.service_arguments
+
+  Ibexa\Platform\Search\View\SearchListViewBuilder:
+      arguments:
+          $viewConfigurator: '@ezpublish.view.configurator'
+          $viewParametersInjector: '@ezpublish.view.view_parameters.injector.dispatcher'
+
+  Ibexa\Platform\Search\View\SearchListViewProvider:
+      arguments:
+          $matcherFactory: '@platform.user.view.search_list.matcher_factory.dynamically_configured'
+      tags:
+         - { name: ezpublish.view_provider, type: Ibexa\Platform\Search\View\SearchListView, priority: 10 }
+
+  platform.view.search_list.matcher_factory:
+      class: eZ\Bundle\EzPublishCoreBundle\Matcher\ServiceAwareMatcherFactory
+      arguments:
+        - '@eZ\Bundle\EzPublishCoreBundle\Matcher\ViewMatcherRegistry'
+        - '@ezpublish.api.repository'
+        - 'Ibexa\Platform\Search\View'
+
+  platform.user.view.search_list.matcher_factory.dynamically_configured:
+      class: eZ\Publish\Core\MVC\Symfony\Matcher\DynamicallyConfiguredMatcherFactoryDecorator
+      decorates: platform.view.search_list.matcher_factory
+      arguments:
+          $innerConfigurableMatcherFactory: '@platform.user.view.search_list.matcher_factory.dynamically_configured.inner'
+          $configResolver: '@ezpublish.config.resolver'
+          $parameterName: search_list_view

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -1,0 +1,15 @@
+services:
+  _defaults:
+      autoconfigure: true
+      autowire: true
+      public: false
+
+      EzSystems\EzPlatformAdminUiBundle\Controller\SearchController:
+          parent: Symfony\Bundle\FrameworkBundle\Controller\AbstractController
+          autowire: true
+          lazy: true
+          arguments:
+              $searchQueryType: '@EzSystems\EzPlatformAdminUi\QueryType\SearchQueryType'
+              $configResolver: '@ezpublish.config.resolver'
+          tags:
+              - controller.service_arguments

--- a/src/bundle/Resources/translations/pagination.en.xlf
+++ b/src/bundle/Resources/translations/pagination.en.xlf
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+  <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <header>
+      <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+      <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+    </header>
+    <body>
+      <trans-unit id="663d5cd498c0849675ac4fd684d4270a1a3f1acb" resname="pagination.viewing">
+        <source><![CDATA[Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items]]></source>
+        <target state="new"><![CDATA[Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items]]></target>
+        <note>key: pagination.viewing</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/bundle/Resources/translations/search.en.xlf
+++ b/src/bundle/Resources/translations/search.en.xlf
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:jms="urn:jms:translation" version="1.2">
+  <file source-language="en" target-language="en" datatype="plaintext" original="not.available">
+    <header>
+      <tool tool-id="JMSTranslationBundle" tool-name="JMSTranslationBundle" tool-version="1.1.0-DEV"/>
+      <note>The source node in most cases contains the sample message as written by the developer. If it looks like a dot-delimitted string such as "form.label.firstname", then the developer has not provided a default message.</note>
+    </header>
+    <body>
+      <trans-unit id="2c0d71c1688c1f04ff156bb9dff167ca5ae663b6" resname="search.any.content.type">
+        <source>Any Content Type</source>
+        <target state="new">Any Content Type</target>
+        <note>key: search.any.content.type</note>
+      </trans-unit>
+      <trans-unit id="52574f2c1d5e0b3ffcd4f105b770e91ae1e519fa" resname="search.content.type">
+        <source>Content Type:</source>
+        <target state="new">Content Type:</target>
+        <note>key: search.content.type</note>
+      </trans-unit>
+      <trans-unit id="738c66eb92535505455b34b383f8089fb1bc0479" resname="search.created">
+        <source>Created:</source>
+        <target state="new">Created:</target>
+        <note>key: search.created</note>
+      </trans-unit>
+      <trans-unit id="a32fe0699ebb4545ab1a39bab0311633c3f92fc3" resname="search.creator">
+        <source>Creator:</source>
+        <target state="new">Creator:</target>
+        <note>key: search.creator</note>
+      </trans-unit>
+      <trans-unit id="3d9f547776de4846ff54fcd1cd173ac5937e5a46" resname="search.creator_input.placeholder">
+        <source>Type creator's name</source>
+        <target state="new">Type creator's name</target>
+        <note>key: search.creator_input.placeholder</note>
+      </trans-unit>
+      <trans-unit id="0ec8148d681b43e87a6d0751fff188517be1ea26" resname="search.header">
+        <source>Search results (%total%)</source>
+        <target state="new">Search results (%total%)</target>
+        <note>key: search.header</note>
+      </trans-unit>
+      <trans-unit id="c2e9df867c114a94918c00f775d3a54d24358dfa" resname="search.last.modified">
+        <source>Last modified:</source>
+        <target state="new">Last modified:</target>
+        <note>key: search.last.modified</note>
+      </trans-unit>
+      <trans-unit id="0ea91510ce49731de30d4d412dc62c83c91b359d" resname="search.modified">
+        <source>Modified</source>
+        <target state="new">Modified</target>
+        <note>key: search.modified</note>
+      </trans-unit>
+      <trans-unit id="6fc6d2e87716ae8feb2ff4536efa8c9db0904509" resname="search.name">
+        <source>Name</source>
+        <target state="new">Name</target>
+        <note>key: search.name</note>
+      </trans-unit>
+      <trans-unit id="8c11cc36acf58db9ff898f3a4cf02fd0fc293f67" resname="search.no_result">
+        <source>No results found for "%query%".</source>
+        <target state="new">No results found for "%query%".</target>
+        <note>key: search.no_result</note>
+      </trans-unit>
+      <trans-unit id="6ffbb9b14f98e94b8dda5418ef3910942b42c44e" resname="search.search">
+        <source>Search</source>
+        <target state="new">Search</target>
+        <note>key: search.search</note>
+      </trans-unit>
+      <trans-unit id="34cd11448c2016e5c0a098947eb3e2aef01a9ac5" resname="search.section">
+        <source>Section:</source>
+        <target state="new">Section:</target>
+        <note>key: search.section</note>
+      </trans-unit>
+      <trans-unit id="777cc1ef279096d5a978aa3553e9434d828f8248" resname="search.tips.check_spelling">
+        <source>Check the spelling of keywords.</source>
+        <target state="new">Check the spelling of keywords.</target>
+        <note>key: search.tips.check_spelling</note>
+      </trans-unit>
+      <trans-unit id="d89a8ff5c4b03f1dd7bd1ce3e3306862e1855751" resname="search.tips.different_keywords">
+        <source>Try different keywords.</source>
+        <target state="new">Try different keywords.</target>
+        <note>key: search.tips.different_keywords</note>
+      </trans-unit>
+      <trans-unit id="013ced9a3284ecebf5a5356397dc9a79eaf76496" resname="search.tips.fewer_keywords">
+        <source>Try fewer keywords. Reducing keywords results in more matches.</source>
+        <target state="new">Try fewer keywords. Reducing keywords results in more matches.</target>
+        <note>key: search.tips.fewer_keywords</note>
+      </trans-unit>
+      <trans-unit id="4af1e76946070e5f61320621d12a171f4206e06c" resname="search.tips.headline">
+        <source>Some helpful search tips:</source>
+        <target state="new">Some helpful search tips:</target>
+        <note>key: search.tips.headline</note>
+      </trans-unit>
+      <trans-unit id="dd61516edc919235a13e3cfadb5d961b8614b744" resname="search.tips.more_general_keywords">
+        <source>Try more general keywords.</source>
+        <target state="new">Try more general keywords.</target>
+        <note>key: search.tips.more_general_keywords</note>
+      </trans-unit>
+      <trans-unit id="e477a87ca96bb3e22e8eed710e54e9a6bffefc52" resname="search.translations">
+        <source>Translations</source>
+        <target state="new">Translations</target>
+        <note>key: search.translations</note>
+      </trans-unit>
+      <trans-unit id="0c9866a19fd5d3074bdb05b339df05b7c05a5661" resname="search.type">
+        <source>Content Type</source>
+        <target state="new">Content Type</target>
+        <note>key: search.type</note>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/src/bundle/Resources/views/themes/standard/search/form.html.twig
+++ b/src/bundle/Resources/views/themes/standard/search/form.html.twig
@@ -1,0 +1,178 @@
+{% form_theme form '@ezdesign/ui/form_fields.html.twig' %}
+
+{% trans_default_domain 'search' %}
+
+{% set content_breadcrumbs = '' %}
+{% set subtree_selected = form.subtree.vars.value is not empty %}
+
+{{ form_start(form, {'attr': {'class': 'ez-search-form'}}) }}
+<div class="input-group px-4">
+    {{ form_widget(form.query) }}
+
+    <span class="input-group-btn">
+        <button type="submit" class="btn btn-primary font-weight-bold ez-btn--search">
+            <svg class="ez-icon ez-icon--medium ez-icon--light">
+                <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#search"></use>
+            </svg>
+            <span class="ez-btn ez-btn--search-label">{{ 'search.perform'|trans|desc('Search') }}</span>
+        </button>
+        <span class="ml-4" {% if form.search_language.vars.choices|length == 1 %}hidden{% endif %}>
+            {{ form_widget(form.search_language, {'attr': {'class': 'ez-search-form__language-selector'}}) }}
+        </span>
+        <button type="button" class="btn btn-dark ez-btn--filter ml-4">
+            <svg class="ez-icon ez-icon--medium ez-icon--light ez-icon-filters">
+                <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#filters"></use>
+            </svg>
+            <span class="ez-btn ez-btn--filter-label">{{ 'search.filters'|trans|desc('Filters') }}</span>
+        </button>
+    </span>
+</div>
+
+<div class="ez-search-criteria-tags ml-4">
+    {% if form.content_types.vars.data is not empty %}
+        {% for content_type in form.content_types.vars.data %}
+            {{ include('@ezdesign/ui/search_tag.html.twig', {
+                'content': content_type.name,
+                'title': "#{'search.content.type'|trans|desc('Content Type:')} #{content_type.name}",
+                'target_selector': "#search_content_types_#{content_type.identifier}",
+                'btn_class': "ez-tag__remove-btn--content-types",
+            }) }}
+        {% endfor %}
+    {% endif %}
+
+    {% if form.section is defined and form.section.vars.data is not empty %}
+        {{ include('@ezdesign/ui/search_tag.html.twig', {
+            'content': form.section.vars.data.name,
+            'title': "#{'search.section'|trans|desc('Section:')} #{form.section.vars.data.name}",
+            'btn_class': "ez-tag__remove-btn--section",
+        }) }}
+    {% endif %}
+
+    {% if form.subtree.vars.value is not empty %}
+        {% if subtree_selected %}
+            {% set path_locations = ez_path_to_locations(form.subtree.vars.value) %}
+            {% for location in path_locations %}
+                {% set content_breadcrumbs = content_breadcrumbs ~ ez_content_name(location.contentInfo) %}
+                {% if not loop.last %}
+                    {% set content_breadcrumbs = content_breadcrumbs ~ ' / ' %}
+                {% endif %}
+            {% endfor %}
+        {% endif %}
+
+        {{ include('@ezdesign/ui/search_tag.html.twig', {
+            'content': content_breadcrumbs,
+            'title':  "#{'search.subtree'|trans|desc('Subtree:')} #{content_breadcrumbs}",
+            'btn_class': "ez-tag__remove-btn--subtree",
+        }) }}
+    {% endif %}
+
+    {% if form.vars.value.lastModified is not empty %}
+        {% set start_date = form.vars.value.lastModified.start_date|ez_short_date %}
+        {% set end_date = form.vars.value.lastModified.end_date|ez_short_date %}
+
+        {{ include('@ezdesign/ui/search_tag.html.twig', {
+            'content': "#{'search.last.modified'|trans|desc('Last modified:')} #{start_date} - #{end_date}",
+            'btn_class': "ez-tag__remove-btn--last-modified",
+        }) }}
+    {% endif %}
+
+    {% if form.vars.value.created is not empty %}
+        {% set start_date = form.vars.value.created.start_date|ez_short_date %}
+        {% set end_date = form.vars.value.created.end_date|ez_short_date %}
+
+        {{ include('@ezdesign/ui/search_tag.html.twig', {
+            'content': "#{'search.created'|trans|desc('Created:')} #{start_date} - #{end_date}",
+            'btn_class': "ez-tag__remove-btn--last-created",
+        }) }}
+    {% endif %}
+
+    {% if form.creator.vars.data is not empty %}
+        {{ include('@ezdesign/ui/search_tag.html.twig', {
+            'content': form.creator.vars.data.name,
+            'title': "#{'search.creator'|trans|desc('Creator:')} #{form.creator.vars.data.name}",
+            'btn_class': "ez-tag__remove-btn--creator",
+        }) }}
+    {% endif %}
+</div>
+
+<div class="ez-filters mt-4 ml-4 pt-2 ez-filters--collapsed">
+    <div class="ez-filters__row">
+        <div class="ez-filters__item ez-filters__item--content-type">
+            <label class="ez-filters__item-label">{{ 'search.content.type'|trans|desc('Content Type:') }}</label>
+            <select class="form-control ez-filters__select ez-filters__select--content-type" hidden>
+                <option class="ez-filters__option ez-filters__option--hidden" data-default="{{ 'search.any.content.type'|trans|desc('Any Content Type') }}" value="">{{ 'search.any.content.type'|trans|desc('Any Content Type') }}</option>
+            </select>
+            {{ form_widget(form.content_types, {'attr': {'class': 'ez-filters__select'}}) }}
+        </div>
+    </div>
+    <div class="ez-filters__row">
+        {% if form.section is defined %}
+            <div class="ez-filters__item ez-filters__item--section">
+                <label class="ez-filters__item-label">{{ 'search.section'|trans|desc('Section:') }}</label>
+                {{ form_widget(form.section, {'attr': {'class': 'ez-filters__select'}}) }}
+            </div>
+        {% endif %}
+        <div class="ez-filters__item ez-filters__item--subtree">
+            <label class="ez-filters__item-label">{{ 'search.subtree'|trans|desc('Subtree:') }}</label>
+            <div>
+                <button class="btn btn-secondary ez-btn--udw-select-location"
+                    type="button"
+                    {% if form.subtree.vars.value is not empty %} hidden {% endif %}
+                    data-universal-discovery-title="{{'search.udw.select_content'|trans|desc('Select Content')}}"
+                    data-location-path-input-selector="#{{form.subtree.vars.id}}"
+                    data-content-breadcrumbs-selector="#{{form.subtree.vars.id}}-content-breadcrumbs"
+                    data-udw-config="{{ ez_udw_config('single_container', {}) }}"
+                    >{{'search.select_content'|trans|desc('Select Content')}}</button>
+
+                {{ include('@ezdesign/ui/tag.html.twig', {
+                    'content': content_breadcrumbs,
+                    'is_loading_state': false,
+                    'tag_attributes': {
+                        'hidden': not subtree_selected,
+                        'id': form.subtree.vars.id ~ '-content-breadcrumbs',
+                    }
+                }) }}
+            </div>
+            {{ form_widget(form.subtree) }}
+        </div>
+    </div>
+    <div class="ez-filters__row">
+        <div class="ez-filters__item ez-filters__item--modified">
+            <label class="ez-filters__item-label">{{ 'search.last.modified'|trans|desc('Last modified:') }}</label>
+            {{ form_widget(form.last_modified_select, {'attr': {'class': 'ez-filters__select', 'data-target-selector': '.ez-filters__range-wrapper--select-modified-range'}}) }}
+            {{ form_errors(form.last_modified_select) }}
+        </div>
+        <div class="ez-filters__item ez-filters__item--created">
+            <label class="ez-filters__item-label">{{ 'search.created'|trans|desc('Created:') }}</label>
+            {{ form_widget(form.created_select, {'attr': {'class': 'ez-filters__select', 'data-target-selector': '.ez-filters__range-wrapper--select-created-range'}}) }}
+            {{ form_errors(form.created_select) }}
+        </div>
+        <div class="ez-filters__item ez-filters__item--creator">
+            <label class="ez-filters__item-label">{{ 'search.creator'|trans|desc('Creator:') }}</label>
+            {% set creator = form.vars.data.creator %}
+            <div class="ez-filters__input-wrapper">
+                <input type="text"
+                    class="form-control ez-filters__input"
+                    data-content-type-identifiers="{{ user_content_type_identifier|join(',') }}"
+                    value="{{ creator is not empty ? ez_content_name(creator) }}"
+                    placeholder="{{ 'search.creator_input.placeholder'|trans|desc('Type creator\'s name') }}"
+                    {{ creator is not empty ? 'disabled'  }}
+                >
+                <svg class="ez-icon ez-icon--dark ez-icon--medium ez-icon--reset">
+                    <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#circle-close"></use>
+                </svg>
+            </div>
+            <ul class="ez-filters__user-list ez-filters__user-list--hidden"></ul>
+        </div>
+    </div>
+    <div class="ez-filters__btns">
+        <button class="btn btn-dark ez-btn-clear">
+            {{ 'search.clear'|trans|desc('Clear') }}</button>
+        <button type="submit" class="btn btn-secondary ez-btn-apply font-weight-bold" disabled>
+            {{ 'search.apply'|trans|desc('Apply') }}</button>
+    </div>
+</div>
+{{ form_widget(form.last_modified, {'attr': {'hidden': 'hidden'}}) }}
+{{ form_widget(form.created, {'attr': {'hidden': 'hidden'}}) }}
+{{ form_widget(form.creator, {'attr': {'hidden': 'hidden'}}) }}
+{{ form_end(form) }}

--- a/src/bundle/Resources/views/themes/standard/search/form.html.twig
+++ b/src/bundle/Resources/views/themes/standard/search/form.html.twig
@@ -1,98 +1,14 @@
-{% form_theme form '@ezdesign/ui/form_fields.html.twig' %}
-
 {% trans_default_domain 'search' %}
-
-{% set content_breadcrumbs = '' %}
-{% set subtree_selected = form.subtree.vars.value is not empty %}
 
 {{ form_start(form, {'attr': {'class': 'ez-search-form'}}) }}
 <div class="input-group px-4">
     {{ form_widget(form.query) }}
 
     <span class="input-group-btn">
-        <button type="submit" class="btn btn-primary font-weight-bold ez-btn--search">
-            <svg class="ez-icon ez-icon--medium ez-icon--light">
-                <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#search"></use>
-            </svg>
-            <span class="ez-btn ez-btn--search-label">{{ 'search.perform'|trans|desc('Search') }}</span>
-        </button>
         <span class="ml-4" {% if form.search_language.vars.choices|length == 1 %}hidden{% endif %}>
             {{ form_widget(form.search_language, {'attr': {'class': 'ez-search-form__language-selector'}}) }}
         </span>
-        <button type="button" class="btn btn-dark ez-btn--filter ml-4">
-            <svg class="ez-icon ez-icon--medium ez-icon--light ez-icon-filters">
-                <use xlink:href="{{ asset('bundles/ezplatformadminui/img/ez-icons.svg') }}#filters"></use>
-            </svg>
-            <span class="ez-btn ez-btn--filter-label">{{ 'search.filters'|trans|desc('Filters') }}</span>
-        </button>
     </span>
-</div>
-
-<div class="ez-search-criteria-tags ml-4">
-    {% if form.content_types.vars.data is not empty %}
-        {% for content_type in form.content_types.vars.data %}
-            {{ include('@ezdesign/ui/search_tag.html.twig', {
-                'content': content_type.name,
-                'title': "#{'search.content.type'|trans|desc('Content Type:')} #{content_type.name}",
-                'target_selector': "#search_content_types_#{content_type.identifier}",
-                'btn_class': "ez-tag__remove-btn--content-types",
-            }) }}
-        {% endfor %}
-    {% endif %}
-
-    {% if form.section is defined and form.section.vars.data is not empty %}
-        {{ include('@ezdesign/ui/search_tag.html.twig', {
-            'content': form.section.vars.data.name,
-            'title': "#{'search.section'|trans|desc('Section:')} #{form.section.vars.data.name}",
-            'btn_class': "ez-tag__remove-btn--section",
-        }) }}
-    {% endif %}
-
-    {% if form.subtree.vars.value is not empty %}
-        {% if subtree_selected %}
-            {% set path_locations = ez_path_to_locations(form.subtree.vars.value) %}
-            {% for location in path_locations %}
-                {% set content_breadcrumbs = content_breadcrumbs ~ ez_content_name(location.contentInfo) %}
-                {% if not loop.last %}
-                    {% set content_breadcrumbs = content_breadcrumbs ~ ' / ' %}
-                {% endif %}
-            {% endfor %}
-        {% endif %}
-
-        {{ include('@ezdesign/ui/search_tag.html.twig', {
-            'content': content_breadcrumbs,
-            'title':  "#{'search.subtree'|trans|desc('Subtree:')} #{content_breadcrumbs}",
-            'btn_class': "ez-tag__remove-btn--subtree",
-        }) }}
-    {% endif %}
-
-    {% if form.vars.value.lastModified is not empty %}
-        {% set start_date = form.vars.value.lastModified.start_date|ez_short_date %}
-        {% set end_date = form.vars.value.lastModified.end_date|ez_short_date %}
-
-        {{ include('@ezdesign/ui/search_tag.html.twig', {
-            'content': "#{'search.last.modified'|trans|desc('Last modified:')} #{start_date} - #{end_date}",
-            'btn_class': "ez-tag__remove-btn--last-modified",
-        }) }}
-    {% endif %}
-
-    {% if form.vars.value.created is not empty %}
-        {% set start_date = form.vars.value.created.start_date|ez_short_date %}
-        {% set end_date = form.vars.value.created.end_date|ez_short_date %}
-
-        {{ include('@ezdesign/ui/search_tag.html.twig', {
-            'content': "#{'search.created'|trans|desc('Created:')} #{start_date} - #{end_date}",
-            'btn_class': "ez-tag__remove-btn--last-created",
-        }) }}
-    {% endif %}
-
-    {% if form.creator.vars.data is not empty %}
-        {{ include('@ezdesign/ui/search_tag.html.twig', {
-            'content': form.creator.vars.data.name,
-            'title': "#{'search.creator'|trans|desc('Creator:')} #{form.creator.vars.data.name}",
-            'btn_class': "ez-tag__remove-btn--creator",
-        }) }}
-    {% endif %}
 </div>
 
 <div class="ez-filters mt-4 ml-4 pt-2 ez-filters--collapsed">
@@ -112,29 +28,6 @@
                 {{ form_widget(form.section, {'attr': {'class': 'ez-filters__select'}}) }}
             </div>
         {% endif %}
-        <div class="ez-filters__item ez-filters__item--subtree">
-            <label class="ez-filters__item-label">{{ 'search.subtree'|trans|desc('Subtree:') }}</label>
-            <div>
-                <button class="btn btn-secondary ez-btn--udw-select-location"
-                    type="button"
-                    {% if form.subtree.vars.value is not empty %} hidden {% endif %}
-                    data-universal-discovery-title="{{'search.udw.select_content'|trans|desc('Select Content')}}"
-                    data-location-path-input-selector="#{{form.subtree.vars.id}}"
-                    data-content-breadcrumbs-selector="#{{form.subtree.vars.id}}-content-breadcrumbs"
-                    data-udw-config="{{ ez_udw_config('single_container', {}) }}"
-                    >{{'search.select_content'|trans|desc('Select Content')}}</button>
-
-                {{ include('@ezdesign/ui/tag.html.twig', {
-                    'content': content_breadcrumbs,
-                    'is_loading_state': false,
-                    'tag_attributes': {
-                        'hidden': not subtree_selected,
-                        'id': form.subtree.vars.id ~ '-content-breadcrumbs',
-                    }
-                }) }}
-            </div>
-            {{ form_widget(form.subtree) }}
-        </div>
     </div>
     <div class="ez-filters__row">
         <div class="ez-filters__item ez-filters__item--modified">
@@ -158,18 +51,14 @@
                     placeholder="{{ 'search.creator_input.placeholder'|trans|desc('Type creator\'s name') }}"
                     {{ creator is not empty ? 'disabled'  }}
                 >
-                <svg class="ez-icon ez-icon--dark ez-icon--medium ez-icon--reset">
-                    <use xlink:href="/bundles/ezplatformadminui/img/ez-icons.svg#circle-close"></use>
-                </svg>
             </div>
             <ul class="ez-filters__user-list ez-filters__user-list--hidden"></ul>
         </div>
     </div>
     <div class="ez-filters__btns">
-        <button class="btn btn-dark ez-btn-clear">
-            {{ 'search.clear'|trans|desc('Clear') }}</button>
-        <button type="submit" class="btn btn-secondary ez-btn-apply font-weight-bold" disabled>
-            {{ 'search.apply'|trans|desc('Apply') }}</button>
+        <button type="submit" class="btn btn-secondary ez-btn-apply font-weight-bold">
+            {{ 'search.search'|trans|desc('Search') }}
+        </button>
     </div>
 </div>
 {{ form_widget(form.last_modified, {'attr': {'hidden': 'hidden'}}) }}

--- a/src/bundle/Resources/views/themes/standard/search/form.html.twig
+++ b/src/bundle/Resources/views/themes/standard/search/form.html.twig
@@ -3,7 +3,6 @@
 {{ form_start(form, {'attr': {'class': 'ez-search-form'}}) }}
 <div class="input-group px-4">
     {{ form_widget(form.query) }}
-
     <span class="input-group-btn">
         <span class="ml-4" {% if form.search_language.vars.choices|length == 1 %}hidden{% endif %}>
             {{ form_widget(form.search_language, {'attr': {'class': 'ez-search-form__language-selector'}}) }}

--- a/src/bundle/Resources/views/themes/standard/search/index.html.twig
+++ b/src/bundle/Resources/views/themes/standard/search/index.html.twig
@@ -1,0 +1,103 @@
+{% extends "@ezdesign/ui/layout.html.twig" %}
+
+{% trans_default_domain 'search' %}
+
+{% block page_title %}{% endblock %}
+
+{% block body_class %}ez-search-view ez-has-two-sidebars{% endblock %}
+
+{% block title %}{{ 'search'|trans|desc('Search') }}{% endblock %}
+
+{% block content %}
+    <div class="row align-items-stretch ez-main-row">
+
+        {% block left_sidebar %}
+            {{ parent() }}
+        {% endblock left_sidebar %}
+
+        <div class="px-0 ez-content-container">
+            <section class="container mt-5">
+                {% include '@ezdesign/ui/page_title.html.twig' with { title: 'search.headline'|trans|desc('Search'), icon_name: 'search' } %}
+                {% include '@ezdesign/ui/search/form.html.twig' with { form: form } %}
+
+                {% if results is defined %}
+
+                    <div class="ez-table-header mt-3 mx-4">
+                        <div class="ez-table-header__headline">{{ 'search.header'|trans({'%total%': pager.nbResults})|desc('Search results (%total%)') }}</div>
+                    </div>
+
+                    {% if results is empty %}
+                        <div class="mx-4">
+                            <table class="table">
+                                <tr>
+                                    <td colspan="4">
+                                        <span>{{ 'search.no_result'|trans({'%query%': form.vars.value.query})|desc('No results found for "%query%".') }}</span>
+                                    </td>
+                                </tr>
+                            </table>
+                            <h6>{{ 'search.tips.headline'|trans|desc('Some helpful search tips:') }}</h6>
+                            <ul>
+                                <li>{{ 'search.tips.check_spelling'|trans|desc('Check the spelling of keywords.') }}</li>
+                                <li>{{ 'search.tips.different_keywords'|trans|desc('Try different keywords.') }}</li>
+                                <li>{{ 'search.tips.more_general_keywords'|trans|desc('Try more general keywords.') }}</li>
+                                <li>{{ 'search.tips.fewer_keywords'|trans|desc('Try fewer keywords. Reducing keywords results in more matches.') }}</li>
+                            </ul>
+                        </div>
+                    {% else %}
+                        <div class="ez-scrollable-table-wrapper mx-4">
+                            <table class="table">
+                                <thead>
+                                <tr>
+                                    <th class="ez-table__header-cell ez-table__header-cell--has-icon"></th>
+                                    <th class="ez-table__header-cell ez-table__header-cell--after-icon">{{ 'search.name'|trans|desc('Name') }}</th>
+                                    <th class="ez-table__header-cell">{{ 'search.modified'|trans|desc('Modified') }}</th>
+                                    <th class="ez-table__header-cell">{{ 'search.type'|trans|desc('Content Type') }}</th>
+                                    {% if form.search_language.vars.choices|length > 1 %}
+                                        <th class="ez-table__header-cell">{{ 'search.translations'|trans|desc('Translations') }}</th>
+                                    {% endif %}
+                                    <th class="ez-table__header-cell"></th>
+                                </tr>
+                                </thead>
+                                <tbody>
+                                {% for row in results %}
+                                    {% include '@ezdesign/ui/search/list_item.html.twig' with { row: row } %}
+                                {% endfor %}
+                                </tbody>
+                            </table>
+                        </div>
+
+                        {% if pager.haveToPaginate %}
+                            <div class="row justify-content-center align-items-center mb-2 ml-4 ez-pagination__spacing">
+                                <span class="ez-pagination__text">
+                                    {{ 'pagination.viewing'|trans({
+                                        '%viewing%': pager.currentPageResults|length,
+                                        '%total%': pager.nbResults}, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
+                                </span>
+                            </div>
+                            <div class="row justify-content-center align-items-center ez-pagination__btn mb-5 mx-4">
+                                {{ pagerfanta(pager, 'ez', {'pageParameter': '[search][page]'}) }}
+                            </div>
+                        {% endif %}
+                    {% endif %}
+
+                    {% form_theme form_edit '@ezdesign/ui/form/flat_widgets.html.twig' %}
+
+                    {{ form_start(form_edit, {
+                        'action': path('ezplatform.content.edit'),
+                        'attr': { 'class': 'ez-edit-content-form'}
+                    }) }}
+                    {{ form_widget(form_edit.language, {'attr': {'hidden': 'hidden', 'class': 'language-input'}}) }}
+                    {{ form_end(form_edit) }}
+                {% endif %}
+            </section>
+        </div>
+    </div>
+{% endblock %}
+
+{% block react_modules %}
+    {{ encore_entry_script_tags('ezplatform-admin-ui-content-tree-js', null, 'ezplatform') }}
+{% endblock %}
+
+{% block javascripts %}
+    {{ encore_entry_script_tags('ezplatform-admin-ui-search-js', null, 'ezplatform') }}
+{% endblock %}

--- a/src/bundle/Resources/views/themes/standard/search/index.html.twig
+++ b/src/bundle/Resources/views/themes/standard/search/index.html.twig
@@ -1,24 +1,10 @@
-{% extends "@ezdesign/ui/layout.html.twig" %}
-
 {% trans_default_domain 'search' %}
-
-{% block page_title %}{% endblock %}
-
-{% block body_class %}ez-search-view ez-has-two-sidebars{% endblock %}
-
-{% block title %}{{ 'search'|trans|desc('Search') }}{% endblock %}
 
 {% block content %}
     <div class="row align-items-stretch ez-main-row">
-
-        {% block left_sidebar %}
-            {{ parent() }}
-        {% endblock left_sidebar %}
-
         <div class="px-0 ez-content-container">
             <section class="container mt-5">
-                {% include '@ezdesign/ui/page_title.html.twig' with { title: 'search.headline'|trans|desc('Search'), icon_name: 'search' } %}
-                {% include '@ezdesign/ui/search/form.html.twig' with { form: form } %}
+                {% include '@ezdesign/search/form.html.twig' with { form: form } %}
 
                 {% if results is defined %}
 
@@ -48,7 +34,6 @@
                             <table class="table">
                                 <thead>
                                 <tr>
-                                    <th class="ez-table__header-cell ez-table__header-cell--has-icon"></th>
                                     <th class="ez-table__header-cell ez-table__header-cell--after-icon">{{ 'search.name'|trans|desc('Name') }}</th>
                                     <th class="ez-table__header-cell">{{ 'search.modified'|trans|desc('Modified') }}</th>
                                     <th class="ez-table__header-cell">{{ 'search.type'|trans|desc('Content Type') }}</th>
@@ -60,7 +45,7 @@
                                 </thead>
                                 <tbody>
                                 {% for row in results %}
-                                    {% include '@ezdesign/ui/search/list_item.html.twig' with { row: row } %}
+                                    {% include '@ezdesign/search/list_item.html.twig' with { row: row } %}
                                 {% endfor %}
                                 </tbody>
                             </table>
@@ -79,25 +64,8 @@
                             </div>
                         {% endif %}
                     {% endif %}
-
-                    {% form_theme form_edit '@ezdesign/ui/form/flat_widgets.html.twig' %}
-
-                    {{ form_start(form_edit, {
-                        'action': path('ezplatform.content.edit'),
-                        'attr': { 'class': 'ez-edit-content-form'}
-                    }) }}
-                    {{ form_widget(form_edit.language, {'attr': {'hidden': 'hidden', 'class': 'language-input'}}) }}
-                    {{ form_end(form_edit) }}
                 {% endif %}
             </section>
         </div>
     </div>
-{% endblock %}
-
-{% block react_modules %}
-    {{ encore_entry_script_tags('ezplatform-admin-ui-content-tree-js', null, 'ezplatform') }}
-{% endblock %}
-
-{% block javascripts %}
-    {{ encore_entry_script_tags('ezplatform-admin-ui-search-js', null, 'ezplatform') }}
 {% endblock %}

--- a/src/bundle/Resources/views/themes/standard/search/list_item.html.twig
+++ b/src/bundle/Resources/views/themes/standard/search/list_item.html.twig
@@ -1,0 +1,29 @@
+<tr>
+    <td class="ez-table__cell ez-table__cell--has-icon">
+        <svg class="ez-icon ez-icon--small">
+            <use xlink:href="{{ ez_content_type_icon(row.content_type.identifier) }}"></use>
+        </svg>
+    </td>
+    <td class="ez-table__cell ez-table__cell--after-icon">
+        <a href="{{ path('_ez_content_view', {
+            'contentId': row.contentId,
+            'languageCode': row.translation_language_code,
+        }) }}">{{ row.name }}</a>
+    </td>
+    <td class="ez-table__cell">{{ row.modified|ez_full_datetime }}</td>
+    <td class="ez-table__cell">{{ row.type }}</td>
+    {% if form.search_language.vars.choices|length > 1 %}
+        <td class="ez-table__cell">
+            {% for language in row.available_translations %}
+                {{ language.name }}{% if not loop.last %}, {% endif %}
+            {% endfor %}
+        </td>
+    {% endif %}
+{#    <td class="ez-table__cell ez-table__cell--has-action-btns text-right">#}
+{#        {% include '@ezdesign/ui/edit_translation_button.html.twig' with {#}
+{#            'contentId': row.contentId,#}
+{#            'translations': row.available_enabled_translations,#}
+{#            'top_offset': 100#}
+{#        }%}#}
+{#    </td>#}
+</tr>

--- a/src/bundle/Resources/views/themes/standard/search/list_item.html.twig
+++ b/src/bundle/Resources/views/themes/standard/search/list_item.html.twig
@@ -1,9 +1,4 @@
 <tr>
-    <td class="ez-table__cell ez-table__cell--has-icon">
-        <svg class="ez-icon ez-icon--small">
-            <use xlink:href="{{ ez_content_type_icon(row.content_type.identifier) }}"></use>
-        </svg>
-    </td>
     <td class="ez-table__cell ez-table__cell--after-icon">
         <a href="{{ path('_ez_content_view', {
             'contentId': row.contentId,
@@ -19,11 +14,4 @@
             {% endfor %}
         </td>
     {% endif %}
-{#    <td class="ez-table__cell ez-table__cell--has-action-btns text-right">#}
-{#        {% include '@ezdesign/ui/edit_translation_button.html.twig' with {#}
-{#            'contentId': row.contentId,#}
-{#            'translations': row.available_enabled_translations,#}
-{#            'top_offset': 100#}
-{#        }%}#}
-{#    </td>#}
 </tr>

--- a/src/lib/View/SearchListView.php
+++ b/src/lib/View/SearchListView.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Platform\Search\View;
+
+use eZ\Publish\Core\MVC\Symfony\View\BaseView;
+
+class SearchListView extends BaseView
+{
+}

--- a/src/lib/View/SearchListViewBuilder.php
+++ b/src/lib/View/SearchListViewBuilder.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Platform\Search\View;
+
+use eZ\Publish\Core\MVC\Symfony\View\Builder\ViewBuilder;
+use eZ\Publish\Core\MVC\Symfony\View\Configurator;
+use eZ\Publish\Core\MVC\Symfony\View\ParametersInjector;
+
+class SearchListViewBuilder implements ViewBuilder
+{
+    /** @var \eZ\Publish\Core\MVC\Symfony\View\Configurator */
+    private $viewConfigurator;
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\View\ParametersInjector */
+    private $viewParametersInjector;
+
+    public function __construct(
+        Configurator $viewConfigurator,
+        ParametersInjector $viewParametersInjector
+    ) {
+        $this->viewConfigurator = $viewConfigurator;
+        $this->viewParametersInjector = $viewParametersInjector;
+    }
+
+    public function matches($argument): bool
+    {
+        return 'Ibexa\Platform\Bundle\SearchBundle\Controller\SearchController::searchAction' === $argument;
+    }
+
+    public function buildView(array $parameters): SearchListView
+    {
+        $view = new SearchListView();
+
+        $this->viewParametersInjector->injectViewParameters($view, $parameters);
+        $this->viewConfigurator->configure($view);
+
+        return $view;
+    }
+}

--- a/src/lib/View/SearchListViewProvider.php
+++ b/src/lib/View/SearchListViewProvider.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Platform\Search\View;
+
+use eZ\Publish\Core\MVC\Symfony\Matcher\MatcherFactoryInterface;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use eZ\Publish\Core\MVC\Symfony\View\ViewProvider;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+
+class SearchListViewProvider implements ViewProvider
+{
+    /** @var \eZ\Publish\Core\MVC\Symfony\Matcher\MatcherFactoryInterface */
+    protected $matcherFactory;
+
+    public function __construct(MatcherFactoryInterface $matcherFactory)
+    {
+        $this->matcherFactory = $matcherFactory;
+    }
+
+    public function getView(View $view)
+    {
+        if (($configHash = $this->matcherFactory->match($view)) === null) {
+            return null;
+        }
+
+        return $this->buildSearchListView($configHash);
+    }
+
+    protected function buildSearchListView(array $viewConfig): SearchListView
+    {
+        $view = new SearchListView();
+
+        if (isset($viewConfig['template'])) {
+            $view->setTemplateIdentifier($viewConfig['template']);
+        }
+
+        if (isset($viewConfig['controller'])) {
+            $view->setControllerReference(new ControllerReference($viewConfig['controller']));
+        }
+
+        if (isset($viewConfig['params']) && \is_array($viewConfig['params'])) {
+            $view->addParameters($viewConfig['params']);
+        }
+
+        return $view;
+    }
+}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  https://jira.ez.no/browse/EZP-31651
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

## Desc
 - SearchController is the same as in adminUI, just used Symfony `FormFactory` instead of custom one.
- SearchView builder / provider introduced.
- Simplified front SA search forms.
![image](https://user-images.githubusercontent.com/19517274/84662968-ceb2f080-af1c-11ea-885f-45dec6b7780f.png)

## Use in adminUI:
https://github.com/ezsystems/ezplatform-admin-ui/pull/1400

## TODO
As a followup I would like to extract whole logic from Controller into ViewBuilder / Listeners.
#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)