### PR TITLE
EZP-31693: Used two date inputs instead of datepicker for date range filtering

### DIFF
--- a/src/bundle/Controller/SearchController.php
+++ b/src/bundle/Controller/SearchController.php
@@ -8,12 +8,12 @@ declare(strict_types=1);
 
 namespace Ibexa\Platform\Bundle\SearchBundle\Controller;
 
-use Ibexa\Platform\Search\View\SearchListView;
+use Ibexa\Platform\Search\View\SearchView;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 
 class SearchController extends AbstractController
 {
-    public function searchAction(SearchListView $view): SearchListView
+    public function searchAction(SearchView $view): SearchView
     {
         return $view;
     }

--- a/src/bundle/DependencyInjection/Compiler/ViewBuilderRegistryPass.php
+++ b/src/bundle/DependencyInjection/Compiler/ViewBuilderRegistryPass.php
@@ -8,14 +8,14 @@ declare(strict_types=1);
 
 namespace Ibexa\Platform\Bundle\SearchBundle\DependencyInjection\Compiler;
 
-use Ibexa\Platform\Search\View\SearchListViewBuilder;
+use Ibexa\Platform\Search\View\SearchViewBuilder;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class ViewBuilderRegistryPass implements CompilerPassInterface
 {
     public const VIEW_BUILDER_REGISTRY = 'ezpublish.view_builder.registry';
-    public const VIEW_BUILDER_UPDATE_VIEW = SearchListViewBuilder::class;
+    public const VIEW_BUILDER_UPDATE_VIEW = SearchViewBuilder::class;
 
     public function process(ContainerBuilder $container): void
     {

--- a/src/bundle/DependencyInjection/Configuration/Parser/SearchView.php
+++ b/src/bundle/DependencyInjection/Configuration/Parser/SearchView.php
@@ -10,8 +10,8 @@ namespace Ibexa\Platform\Bundle\SearchBundle\DependencyInjection\Configuration\P
 
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\View;
 
-class SearchListView extends View
+class SearchView extends View
 {
-    public const NODE_KEY = 'search_list_view';
+    public const NODE_KEY = 'search_view';
     public const INFO = 'Template for displaying main search form and results';
 }

--- a/src/bundle/Form/DataTransformer/DateIntervalTransformer.php
+++ b/src/bundle/Form/DataTransformer/DateIntervalTransformer.php
@@ -8,8 +8,8 @@ declare(strict_types=1);
 
 namespace Ibexa\Platform\Bundle\SearchBundle\Form\DataTransformer;
 
+use DateTime;
 use Symfony\Component\Form\DataTransformerInterface;
-use Symfony\Component\Form\Exception\TransformationFailedException;
 
 /**
  * Translates timestamp and DataInterval to domain specific timestamp date range.
@@ -40,29 +40,17 @@ class DateIntervalTransformer implements DataTransformerInterface
      */
     public function reverseTransform($value)
     {
-        if (null === $value || !is_array($value) || empty($value['date_interval'])) {
+        if (null === $value || !\is_array($value)) {
             return [];
         }
 
-        if (!array_key_exists('date_interval', $value) || !array_key_exists('end_date', $value)) {
-            throw new TransformationFailedException(
-                "Invalid data. Value array is missing 'date_interval' and/or 'end_date' keys"
-            );
-        }
+        $startDate = $value['start_date'] ?? (new DateTime())->setTimestamp(0);
+        $endDate = $value['end_date'] ?? new DateTime();
+        $endDate->setTime(23, 59, 59);
 
-        $date = new \DateTime();
-
-        if ($value['end_date']) {
-            $date->setTimestamp($value['end_date']);
-        }
-
-        $date->setTime(23, 59, 59);
-        $endDate = $date->getTimestamp();
-        $interval = new \DateInterval($value['date_interval']);
-        $date->sub($interval);
-        $date->setTime(00, 00, 00);
-        $startDate = $date->getTimestamp();
-
-        return ['start_date' => $startDate, 'end_date' => $endDate];
+        return [
+            'start_date' => $startDate->getTimestamp(),
+            'end_date' => $endDate->getTimestamp(),
+        ];
     }
 }

--- a/src/bundle/Form/Type/DateIntervalType.php
+++ b/src/bundle/Form/Type/DateIntervalType.php
@@ -10,9 +10,8 @@ namespace Ibexa\Platform\Bundle\SearchBundle\Form\Type;
 
 use Ibexa\Platform\Bundle\SearchBundle\Form\DataTransformer\DateIntervalTransformer;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\IntegerType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Form\Extension\Core\Type\DateIntervalType as BaseDateIntervalType;
 
 class DateIntervalType extends AbstractType
 {
@@ -22,15 +21,15 @@ class DateIntervalType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('date_interval', BaseDateIntervalType::class, [
-                'attr' => ['hidden' => true],
-                'input' => 'string',
+            ->add('start_date', DateType::class, [
+                'required' => false,
                 'widget' => 'single_text',
-                'required' => false,
+                'input' => 'datetime',
             ])
-            ->add('end_date', IntegerType::class, [
-                'attr' => ['hidden' => true],
+            ->add('end_date', DateType::class, [
                 'required' => false,
+                'widget' => 'single_text',
+                'input' => 'datetime',
             ])
             ->addModelTransformer(new DateIntervalTransformer());
     }

--- a/src/bundle/PlatformSearchBundle.php
+++ b/src/bundle/PlatformSearchBundle.php
@@ -8,7 +8,7 @@ namespace Ibexa\Platform\Bundle\SearchBundle;
 
 use Ibexa\Platform\Bundle\SearchBundle\DependencyInjection\Compiler\ViewBuilderRegistryPass;
 use Ibexa\Platform\Bundle\SearchBundle\DependencyInjection\Configuration\Parser\Search;
-use Ibexa\Platform\Bundle\SearchBundle\DependencyInjection\Configuration\Parser\SearchListView;
+use Ibexa\Platform\Bundle\SearchBundle\DependencyInjection\Configuration\Parser\SearchView;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -21,7 +21,7 @@ class PlatformSearchBundle extends Bundle
 
         $core->addDefaultSettings(__DIR__ . '/Resources/config', ['default_settings.yaml']);
         $core->addConfigParser(new Search());
-        $core->addConfigParser(new SearchListView());
+        $core->addConfigParser(new SearchView());
 
         $container->addCompilerPass(new ViewBuilderRegistryPass());
     }

--- a/src/bundle/Resources/config/default_settings.yaml
+++ b/src/bundle/Resources/config/default_settings.yaml
@@ -1,7 +1,7 @@
 parameters:
     ezsettings.site.pagination.search_limit: 10
 
-    ezsettings.site.search_list_view:
+    ezsettings.site.search_view:
         full:
             default:
                 template: "@@ezdesign/search/index.html.twig"

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -48,8 +48,8 @@ services:
 
   Ibexa\Platform\Bundle\SearchBundle\Form\Type\SearchType:
       arguments:
-         $translator: '@translator'
          $permissionResolver: '@eZ\Publish\API\Repository\PermissionResolver'
+         $configResolver: '@ezpublish.config.resolver'
       tags:
         - { name: form.type, alias: Ibexa\Platform\Bundle\SearchBundle\Form\Type\SearchType }
 

--- a/src/bundle/Resources/config/services.yaml
+++ b/src/bundle/Resources/config/services.yaml
@@ -8,7 +8,7 @@ services:
       tags:
           - controller.service_arguments
 
-  Ibexa\Platform\Search\View\SearchListViewBuilder:
+  Ibexa\Platform\Search\View\SearchViewBuilder:
       arguments:
           $viewConfigurator: '@ezpublish.view.configurator'
           $viewParametersInjector: '@ezpublish.view.view_parameters.injector.dispatcher'
@@ -16,28 +16,28 @@ services:
           $pagerSearchContentToDataMapper: '@Ibexa\Platform\Search\Mapper\PagerSearchContentToDataMapper'
           $searchQueryType: '@Ibexa\Platform\Search\QueryType\SearchQueryType'
 
-  Ibexa\Platform\Search\View\SearchListViewProvider:
+  Ibexa\Platform\Search\View\SearchViewProvider:
       arguments:
-          $matcherFactory: '@platform.user.view.search_list.matcher_factory.dynamically_configured'
+          $matcherFactory: '@platform.user.view.search.matcher_factory.dynamically_configured'
       tags:
-         - { name: ezpublish.view_provider, type: Ibexa\Platform\Search\View\SearchListView, priority: 10 }
+         - { name: ezpublish.view_provider, type: Ibexa\Platform\Search\View\SearchView, priority: 10 }
 
-  platform.view.search_list.matcher_factory:
+  platform.view.search.matcher_factory:
       class: eZ\Bundle\EzPublishCoreBundle\Matcher\ServiceAwareMatcherFactory
       arguments:
           $viewMatcherRegistry: '@eZ\Bundle\EzPublishCoreBundle\Matcher\ViewMatcherRegistry'
           $repository: '@ezpublish.api.repository'
           $relativeNamespace: Ibexa\Platform\Search\View
 
-  platform.user.view.search_list.matcher_factory.dynamically_configured:
+  platform.user.view.search.matcher_factory.dynamically_configured:
       class: eZ\Publish\Core\MVC\Symfony\Matcher\DynamicallyConfiguredMatcherFactoryDecorator
-      decorates: platform.view.search_list.matcher_factory
+      decorates: platform.view.search.matcher_factory
       arguments:
-          $innerConfigurableMatcherFactory: '@platform.user.view.search_list.matcher_factory.dynamically_configured.inner'
+          $innerConfigurableMatcherFactory: '@platform.user.view.search.matcher_factory.dynamically_configured.inner'
           $configResolver: '@ezpublish.config.resolver'
-          $parameterName: search_list_view
+          $parameterName: search_view
 
-  Ibexa\Platform\Search\View\SearchListViewFilter:
+  Ibexa\Platform\Search\View\SearchViewFilter:
       arguments:
           $configResolver: '@ezpublish.config.resolver'
           $formFactory: '@Symfony\Component\Form\FormFactoryInterface'

--- a/src/bundle/Resources/views/themes/standard/search/form.html.twig
+++ b/src/bundle/Resources/views/themes/standard/search/form.html.twig
@@ -1,65 +1,59 @@
 {% trans_default_domain 'search' %}
 
-{{ form_start(form, {'attr': {'class': 'ez-search-form'}}) }}
-<div class="input-group px-4">
+{{ form_start(form) }}
+<div>
     {{ form_widget(form.query) }}
-    <span class="input-group-btn">
-        <span class="ml-4" {% if form.search_language.vars.choices|length == 1 %}hidden{% endif %}>
+    <span>
+        <span{% if form.search_language.vars.choices|length == 1 %}hidden{% endif %}>
             {{ form_widget(form.search_language, {'attr': {'class': 'ez-search-form__language-selector'}}) }}
         </span>
     </span>
 </div>
 
-<div class="ez-filters mt-4 ml-4 pt-2 ez-filters--collapsed">
-    <div class="ez-filters__row">
-        <div class="ez-filters__item ez-filters__item--content-type">
-            <label class="ez-filters__item-label">{{ 'search.content.type'|trans|desc('Content Type:') }}</label>
-            <select class="form-control ez-filters__select ez-filters__select--content-type" hidden>
-                <option class="ez-filters__option ez-filters__option--hidden" data-default="{{ 'search.any.content.type'|trans|desc('Any Content Type') }}" value="">{{ 'search.any.content.type'|trans|desc('Any Content Type') }}</option>
-            </select>
+<div>
+    <div>
+        <div>
+            <label>{{ 'search.content.type'|trans|desc('Content Type:') }}</label>
+                <select hidden>
+                    <option data-default="{{ 'search.any.content.type'|trans|desc('Any Content Type') }}" value="">{{ 'search.any.content.type'|trans|desc('Any Content Type') }}</option>
+                </select>
             {{ form_widget(form.content_types, {'attr': {'class': 'ez-filters__select'}}) }}
         </div>
     </div>
-    <div class="ez-filters__row">
+    <div>
         {% if form.section is defined %}
-            <div class="ez-filters__item ez-filters__item--section">
-                <label class="ez-filters__item-label">{{ 'search.section'|trans|desc('Section:') }}</label>
+            <div>
+                <label>{{ 'search.section'|trans|desc('Section:') }}</label>
                 {{ form_widget(form.section, {'attr': {'class': 'ez-filters__select'}}) }}
             </div>
         {% endif %}
     </div>
-    <div class="ez-filters__row">
-        <div class="ez-filters__item ez-filters__item--modified">
-            <label class="ez-filters__item-label">{{ 'search.last.modified'|trans|desc('Last modified:') }}</label>
-            {{ form_widget(form.last_modified_select, {'attr': {'class': 'ez-filters__select', 'data-target-selector': '.ez-filters__range-wrapper--select-modified-range'}}) }}
-            {{ form_errors(form.last_modified_select) }}
+    <div>
+        <div>
+            <label>{{ 'search.last.modified'|trans|desc('Last modified:') }}</label>
+            {{ form_widget(form.last_modified) }}
         </div>
-        <div class="ez-filters__item ez-filters__item--created">
-            <label class="ez-filters__item-label">{{ 'search.created'|trans|desc('Created:') }}</label>
-            {{ form_widget(form.created_select, {'attr': {'class': 'ez-filters__select', 'data-target-selector': '.ez-filters__range-wrapper--select-created-range'}}) }}
-            {{ form_errors(form.created_select) }}
+        <div>
+            <label>{{ 'search.created'|trans|desc('Created:') }}</label>
+            {{ form_widget(form.created) }}
         </div>
-        <div class="ez-filters__item ez-filters__item--creator">
-            <label class="ez-filters__item-label">{{ 'search.creator'|trans|desc('Creator:') }}</label>
+        <div>
+            <label>{{ 'search.creator'|trans|desc('Creator:') }}</label>
             {% set creator = form.vars.data.creator %}
-            <div class="ez-filters__input-wrapper">
+            <div>
                 <input type="text"
-                    class="form-control ez-filters__input"
                     value="{{ creator is not empty ? ez_content_name(creator) }}"
                     placeholder="{{ 'search.creator_input.placeholder'|trans|desc('Type creator\'s name') }}"
                     {{ creator is not empty ? 'disabled'  }}
                 >
             </div>
-            <ul class="ez-filters__user-list ez-filters__user-list--hidden"></ul>
         </div>
     </div>
-    <div class="ez-filters__btns">
-        <button type="submit" class="btn btn-secondary ez-btn-apply font-weight-bold">
+    <div>
+        <button type="submit">
             {{ 'search.search'|trans|desc('Search') }}
         </button>
     </div>
 </div>
-{{ form_widget(form.last_modified, {'attr': {'hidden': 'hidden'}}) }}
-{{ form_widget(form.created, {'attr': {'hidden': 'hidden'}}) }}
 {{ form_widget(form.creator, {'attr': {'hidden': 'hidden'}}) }}
 {{ form_end(form) }}

--- a/src/bundle/Resources/views/themes/standard/search/index.html.twig
+++ b/src/bundle/Resources/views/themes/standard/search/index.html.twig
@@ -1,20 +1,20 @@
 {% trans_default_domain 'search' %}
 
 {% block content %}
-    <div class="row align-items-stretch ez-main-row">
-        <div class="px-0 ez-content-container">
-            <section class="container mt-5">
+    <div>
+        <div>
+            <section>
                 {% include '@ezdesign/search/form.html.twig' with { form: form } %}
 
                 {% if results is defined %}
 
-                    <div class="ez-table-header mt-3 mx-4">
-                        <div class="ez-table-header__headline">{{ 'search.header'|trans({'%total%': pager.nbResults})|desc('Search results (%total%)') }}</div>
+                    <div>
+                        <div>{{ 'search.header'|trans({'%total%': pager.nbResults})|desc('Search results (%total%)') }}</div>
                     </div>
 
                     {% if results is empty %}
-                        <div class="mx-4">
-                            <table class="table">
+                        <div>
+                            <table>
                                 <tr>
                                     <td colspan="4">
                                         <span>{{ 'search.no_result'|trans({'%query%': form.vars.value.query})|desc('No results found for "%query%".') }}</span>
@@ -30,17 +30,17 @@
                             </ul>
                         </div>
                     {% else %}
-                        <div class="ez-scrollable-table-wrapper mx-4">
-                            <table class="table">
+                        <div>
+                            <table>
                                 <thead>
                                 <tr>
-                                    <th class="ez-table__header-cell ez-table__header-cell--after-icon">{{ 'search.name'|trans|desc('Name') }}</th>
-                                    <th class="ez-table__header-cell">{{ 'search.modified'|trans|desc('Modified') }}</th>
-                                    <th class="ez-table__header-cell">{{ 'search.type'|trans|desc('Content Type') }}</th>
+                                    <th>{{ 'search.name'|trans|desc('Name') }}</th>
+                                    <th>{{ 'search.modified'|trans|desc('Modified') }}</th>
+                                    <th>{{ 'search.type'|trans|desc('Content Type') }}</th>
                                     {% if form.search_language.vars.choices|length > 1 %}
-                                        <th class="ez-table__header-cell">{{ 'search.translations'|trans|desc('Translations') }}</th>
+                                        <th>{{ 'search.translations'|trans|desc('Translations') }}</th>
                                     {% endif %}
-                                    <th class="ez-table__header-cell"></th>
+                                    <th></th>
                                 </tr>
                                 </thead>
                                 <tbody>
@@ -52,14 +52,14 @@
                         </div>
 
                         {% if pager.haveToPaginate %}
-                            <div class="row justify-content-center align-items-center mb-2 ml-4 ez-pagination__spacing">
-                                <span class="ez-pagination__text">
+                            <div>
+                                <span>
                                     {{ 'pagination.viewing'|trans({
                                         '%viewing%': pager.currentPageResults|length,
                                         '%total%': pager.nbResults}, 'pagination')|desc('Viewing <strong>%viewing%</strong> out of <strong>%total%</strong> items')|raw }}
                                 </span>
                             </div>
-                            <div class="row justify-content-center align-items-center ez-pagination__btn mb-5 mx-4">
+                            <div>
                                 {{ pagerfanta(pager, 'ez', {'pageParameter': '[search][page]'}) }}
                             </div>
                         {% endif %}

--- a/src/bundle/Resources/views/themes/standard/search/list_item.html.twig
+++ b/src/bundle/Resources/views/themes/standard/search/list_item.html.twig
@@ -1,14 +1,14 @@
 <tr>
-    <td class="ez-table__cell ez-table__cell--after-icon">
+    <td>
         <a href="{{ path('_ez_content_view', {
             'contentId': row.contentId,
             'languageCode': row.translation_language_code,
         }) }}">{{ row.name }}</a>
     </td>
-    <td class="ez-table__cell">{{ row.modified|ez_full_datetime }}</td>
-    <td class="ez-table__cell">{{ row.type }}</td>
+    <td>{{ row.modified|ez_full_datetime }}</td>
+    <td>{{ row.type }}</td>
     {% if form.search_language.vars.choices|length > 1 %}
-        <td class="ez-table__cell">
+        <td>
             {% for language in row.available_translations %}
                 {{ language.name }}{% if not loop.last %}, {% endif %}
             {% endfor %}

--- a/src/lib/View/SearchListViewFilter.php
+++ b/src/lib/View/SearchListViewFilter.php
@@ -73,8 +73,8 @@ class SearchListViewFilter implements EventSubscriberInterface
         $request = $event->getRequest();
 
         $search = $request->query->get('search');
-        $limit = \is_array($search) && $search['limit'] ? (int)$search['limit'] : $this->configResolver->getParameter('pagination.search_limit');
-        $page = \is_array($search) && $search['page'] ? (int)$search['page'] : 1;
+        $limit = isset($search['limit']) ? (int)$search['limit'] : $this->configResolver->getParameter('pagination.search_limit');
+        $page = isset($search['page']) ? (int)$search['page'] : 1;
         $query = $search['query'] ?? '';
         $section = null;
         $creator = null;

--- a/src/lib/View/SearchView.php
+++ b/src/lib/View/SearchView.php
@@ -10,6 +10,6 @@ namespace Ibexa\Platform\Search\View;
 
 use eZ\Publish\Core\MVC\Symfony\View\BaseView;
 
-class SearchListView extends BaseView
+class SearchView extends BaseView
 {
 }

--- a/src/lib/View/SearchViewBuilder.php
+++ b/src/lib/View/SearchViewBuilder.php
@@ -18,7 +18,7 @@ use eZ\Publish\Core\QueryType\QueryType;
 use Ibexa\Platform\Search\Mapper\PagerSearchContentToDataMapper;
 use Pagerfanta\Pagerfanta;
 
-class SearchListViewBuilder implements ViewBuilder
+class SearchViewBuilder implements ViewBuilder
 {
     /** @var \eZ\Publish\Core\MVC\Symfony\View\Configurator */
     private $viewConfigurator;
@@ -54,9 +54,9 @@ class SearchListViewBuilder implements ViewBuilder
         return 'Ibexa\Platform\Bundle\SearchBundle\Controller\SearchController::searchAction' === $argument;
     }
 
-    public function buildView(array $parameters): SearchListView
+    public function buildView(array $parameters): SearchView
     {
-        $view = new SearchListView();
+        $view = new SearchView();
 
         /** @var \Symfony\Component\Form\FormInterface $form */
         $form = $parameters['form'];

--- a/src/lib/View/SearchViewFilter.php
+++ b/src/lib/View/SearchViewFilter.php
@@ -19,7 +19,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 
-class SearchListViewFilter implements EventSubscriberInterface
+class SearchViewFilter implements EventSubscriberInterface
 {
     /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
     private $configResolver;

--- a/src/lib/View/SearchViewProvider.php
+++ b/src/lib/View/SearchViewProvider.php
@@ -13,7 +13,7 @@ use eZ\Publish\Core\MVC\Symfony\View\View;
 use eZ\Publish\Core\MVC\Symfony\View\ViewProvider;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 
-class SearchListViewProvider implements ViewProvider
+class SearchViewProvider implements ViewProvider
 {
     /** @var \eZ\Publish\Core\MVC\Symfony\Matcher\MatcherFactoryInterface */
     protected $matcherFactory;
@@ -32,9 +32,9 @@ class SearchListViewProvider implements ViewProvider
         return $this->buildSearchListView($configHash);
     }
 
-    protected function buildSearchListView(array $viewConfig): SearchListView
+    protected function buildSearchListView(array $viewConfig): SearchView
     {
-        $view = new SearchListView();
+        $view = new SearchView();
 
         if (isset($viewConfig['template'])) {
             $view->setTemplateIdentifier($viewConfig['template']);


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  https://jira.ez.no/browse/EZP-31693
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-search/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

## Desc
For frontend SA, as we do not want to push JS and CSS to front views, I introduced two html5 based date pickers for date range filtering instead of selector + datepicker combo.
https://github.com/ezsystems/ezplatform-search/commit/8e9f4f4cfabae08af4c55aa27d75b13b7157e736

## Additional work:
Filtering when no all filters are send in request.
https://jira.ez.no/browse/EZP-31702
https://github.com/ezsystems/ezplatform-search/commit/63b7aee1135f32f6e037b8910424754b72c4c0fd

I have also cleared basic htmls from our internal css classes:
https://github.com/ezsystems/ezplatform-search/commit/515173620f426ff3f8c04ec22ffb5cf13d05bff6

And as a suggestion from @bdunogier I have renamed `SearchList` to just `Search` as it seems more fitting as the view also contains form, not only results. That also means I have changed `search_list_view` config key to `search_view` @ezsystems/documentation-team 

#### Checklist:
- [x] Implement tests
- [x] Coding standards (`$ composer fix-cs`)
