### PR TITLE
EZP-31745: Introduce PagerSearchDataMapper interface

### DIFF
--- a/src/lib/Mapper/PagerSearchContentToSearchDataMapper.php
+++ b/src/lib/Mapper/PagerSearchContentToSearchDataMapper.php
@@ -20,7 +20,7 @@ use eZ\Publish\Core\Helper\TranslationHelper;
 use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
 use Pagerfanta\Pagerfanta;
 
-class PagerSearchContentToDataMapper
+class PagerSearchContentToSearchDataMapper implements PagerSearchDataMapper
 {
     /** @var \eZ\Publish\API\Repository\ContentTypeService */
     private $contentTypeService;

--- a/src/lib/Mapper/PagerSearchDataMapper.php
+++ b/src/lib/Mapper/PagerSearchDataMapper.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\Platform\Search\Mapper;
+
+use Pagerfanta\Pagerfanta;
+
+interface PagerSearchDataMapper
+{
+    public function map(Pagerfanta $pagerfanta): array;
+}

--- a/src/lib/View/SearchViewBuilder.php
+++ b/src/lib/View/SearchViewBuilder.php
@@ -15,7 +15,7 @@ use eZ\Publish\Core\MVC\Symfony\View\Configurator;
 use eZ\Publish\Core\MVC\Symfony\View\ParametersInjector;
 use eZ\Publish\Core\Pagination\Pagerfanta\ContentSearchHitAdapter;
 use eZ\Publish\Core\QueryType\QueryType;
-use Ibexa\Platform\Search\Mapper\PagerSearchContentToDataMapper;
+use Ibexa\Platform\Search\Mapper\PagerSearchDataMapper;
 use Pagerfanta\Pagerfanta;
 
 class SearchViewBuilder implements ViewBuilder
@@ -29,7 +29,7 @@ class SearchViewBuilder implements ViewBuilder
     /** @var \eZ\Publish\API\Repository\SearchService */
     private $searchService;
 
-    /** @var \Ibexa\Platform\Search\Mapper\PagerSearchContentToDataMapper */
+    /** @var \Ibexa\Platform\Search\Mapper\PagerSearchDataMapper */
     private $pagerSearchContentToDataMapper;
 
     /** @var \eZ\Publish\Core\QueryType\QueryType */
@@ -39,7 +39,7 @@ class SearchViewBuilder implements ViewBuilder
         Configurator $viewConfigurator,
         ParametersInjector $viewParametersInjector,
         SearchService $searchService,
-        PagerSearchContentToDataMapper $pagerSearchContentToDataMapper,
+        PagerSearchDataMapper $pagerSearchContentToDataMapper,
         QueryType $searchQueryType
     ) {
         $this->viewConfigurator = $viewConfigurator;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [EZP-31745](https://jira.ez.no/browse/EZP-31745)
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-search/blob/master/LICENSE)

Currently, if I want to add some extra information in search result template, I can decorate
"Ibexa\Platform\Search\Mapper\PagerSearchContentToDataMapper" service.
But, decorator service is not accepted by SearchViewBuilder.

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
