### PR TITLE
EC-198: Used default bootstrap form_theme for default search form

### DIFF
--- a/src/bundle/Resources/views/themes/standard/search/form.html.twig
+++ b/src/bundle/Resources/views/themes/standard/search/form.html.twig
@@ -1,5 +1,7 @@
 {% trans_default_domain 'search' %}
 
+{% form_theme form 'bootstrap_4_layout.html.twig' %}
+
 {{ form_start(form) }}
 <div>
     {{ form_widget(form.query) }}


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [EC-198](https://jira.ez.no/browse/C-198) <!-- URLs to JIRA issue(s) (or N/A) -->
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-search/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Implement tests
- [x] Coding standards (`$ composer fix-cs`)
