### PR TITLE
EZP-31777: Resolved available Location for searched Content

### DIFF
--- a/src/lib/Mapper/PagerSearchContentToDataMapper.php
+++ b/src/lib/Mapper/PagerSearchContentToDataMapper.php
@@ -18,6 +18,7 @@ use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\Core\Helper\TranslationHelper;
 use eZ\Publish\Core\MVC\Symfony\Locale\UserLanguagePreferenceProviderInterface;
+use eZ\Publish\Core\Repository\LocationResolver\LocationResolver;
 use Pagerfanta\Pagerfanta;
 
 class PagerSearchContentToDataMapper
@@ -37,18 +38,23 @@ class PagerSearchContentToDataMapper
     /** @var \eZ\Publish\API\Repository\LanguageService */
     private $languageService;
 
+    /** @var \eZ\Publish\Core\Repository\LocationResolver\LocationResolver */
+    private $locationResolver;
+
     public function __construct(
         ContentTypeService $contentTypeService,
         UserService $userService,
         UserLanguagePreferenceProviderInterface $userLanguagePreferenceProvider,
         TranslationHelper $translationHelper,
-        LanguageService $languageService
+        LanguageService $languageService,
+        LocationResolver $locationResolver
     ) {
         $this->contentTypeService = $contentTypeService;
         $this->userService = $userService;
         $this->userLanguagePreferenceProvider = $userLanguagePreferenceProvider;
         $this->translationHelper = $translationHelper;
         $this->languageService = $languageService;
+        $this->locationResolver = $locationResolver;
     }
 
     public function map(Pagerfanta $pager): array
@@ -82,6 +88,7 @@ class PagerSearchContentToDataMapper
                 'available_enabled_translations' => $this->getAvailableTranslations($content, true),
                 'available_translations' => $this->getAvailableTranslations($content),
                 'translation_language_code' => $searchHit->matchedTranslation,
+                'resolvedLocation' => $this->locationResolver->resolveLocation($contentInfo),
             ];
         }
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [EZP-31777](https://jira.ez.no/browse/EZP-31777)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-search/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

Search Content should have resolved `LocationId` attribute passed to `_ez_content_view` path.

This PR is a direct follow up of https://github.com/ezsystems/ezplatform-admin-ui/pull/1443 but for v3.1

Related `admin-ui` PR for v3.1: https://github.com/ezsystems/ezplatform-admin-ui/pull/1446

Regression suite: https://github.com/ezsystems/ezplatform-page-builder/pull/637

#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
