### PR TITLE
EZP-32105: Use search.pagination.limit parameter instead of obsolete pagination.search_limit

### DIFF
--- a/src/bundle/Form/Type/SearchType.php
+++ b/src/bundle/Form/Type/SearchType.php
@@ -45,7 +45,7 @@ final class SearchType extends AbstractType
             ->add('query', CoreSearchType::class, ['required' => false])
             ->add('page', HiddenType::class, ['empty_data' => 1])
             ->add('limit', HiddenType::class, [
-                'empty_data' => $this->configResolver->getParameter('pagination.search_limit'),
+                'empty_data' => $this->configResolver->getParameter('search.pagination.limit'),
             ])
             ->add('content_types', ContentTypeChoiceType::class, [
                 'multiple' => true,

--- a/src/bundle/Resources/config/default_settings.yaml
+++ b/src/bundle/Resources/config/default_settings.yaml
@@ -1,7 +1,7 @@
 parameters:
     ezsettings.default.search.pagination.limit: 10
 
-    ezsettings.site.search_view:
+    ezsettings.site_group.search_view:
         full:
             default:
                 template: "@@ezdesign/search/index.html.twig"

--- a/src/bundle/Resources/config/default_settings.yaml
+++ b/src/bundle/Resources/config/default_settings.yaml
@@ -1,5 +1,5 @@
 parameters:
-    ezsettings.site.pagination.search_limit: 10
+    ezsettings.default.search.pagination.limit: 10
 
     ezsettings.site.search_view:
         full:

--- a/src/lib/View/SearchViewFilter.php
+++ b/src/lib/View/SearchViewFilter.php
@@ -73,7 +73,7 @@ class SearchViewFilter implements EventSubscriberInterface
         $request = $event->getRequest();
 
         $search = $request->query->get('search');
-        $limit = isset($search['limit']) ? (int)$search['limit'] : $this->configResolver->getParameter('pagination.search_limit');
+        $limit = isset($search['limit']) ? (int)$search['limit'] : $this->configResolver->getParameter('search.pagination.limit');
         $page = isset($search['page']) ? (int)$search['page'] : 1;
         $query = $search['query'] ?? '';
         $section = null;


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  [EZP-32105](https://jira.ez.no/browse/EZP-32105)
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | yes/no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-search/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


<!-- Replace this comment with Pull Request description -->


#### Checklist:
- [x] Coding standards (`$ composer fix-cs`)
