### PR TITLE
IBX-2: Specified action path for search form for easier reuse

### DIFF
--- a/src/bundle/Resources/config/views.yaml
+++ b/src/bundle/Resources/config/views.yaml
@@ -26,6 +26,7 @@ services:
             $formFactory: '@Symfony\Component\Form\FormFactoryInterface'
             $sectionService: '@ezpublish.api.service.section'
             $contentTypeService: '@ezpublish.api.service.content_type'
+            $router: '@router'
         tags:
             - { name: kernel.event_subscriber }
 

--- a/src/bundle/Resources/config/views.yaml
+++ b/src/bundle/Resources/config/views.yaml
@@ -26,7 +26,7 @@ services:
             $formFactory: '@Symfony\Component\Form\FormFactoryInterface'
             $sectionService: '@ezpublish.api.service.section'
             $contentTypeService: '@ezpublish.api.service.content_type'
-            $router: '@router'
+            $urlGenerator: '@router'
         tags:
             - { name: kernel.event_subscriber }
 

--- a/src/lib/View/SearchViewFilter.php
+++ b/src/lib/View/SearchViewFilter.php
@@ -18,6 +18,7 @@ use Ibexa\Platform\Bundle\Search\Form\Type\SearchType;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\RouterInterface;
 
 class SearchViewFilter implements EventSubscriberInterface
 {
@@ -33,16 +34,21 @@ class SearchViewFilter implements EventSubscriberInterface
     /** @var \eZ\Publish\API\Repository\ContentTypeService */
     private $contentTypeService;
 
+    /** @var \Symfony\Component\Routing\RouterInterface */
+    private $router;
+
     public function __construct(
         ConfigResolverInterface $configResolver,
         FormFactoryInterface $formFactory,
         SectionService $sectionService,
-        ContentTypeService $contentTypeService
+        ContentTypeService $contentTypeService,
+        RouterInterface $router
     ) {
         $this->configResolver = $configResolver;
         $this->formFactory = $formFactory;
         $this->sectionService = $sectionService;
         $this->contentTypeService = $contentTypeService;
+        $this->router = $router;
     }
 
     public static function getSubscribedEvents()
@@ -110,6 +116,7 @@ class SearchViewFilter implements EventSubscriberInterface
             [
                 'method' => Request::METHOD_GET,
                 'csrf_protection' => false,
+                'action' => $this->router->generate('ezplatform.search'),
             ]
         );
 

--- a/src/lib/View/SearchViewFilter.php
+++ b/src/lib/View/SearchViewFilter.php
@@ -18,7 +18,7 @@ use Ibexa\Platform\Bundle\Search\Form\Type\SearchType;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\RouterInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class SearchViewFilter implements EventSubscriberInterface
 {
@@ -34,21 +34,21 @@ class SearchViewFilter implements EventSubscriberInterface
     /** @var \eZ\Publish\API\Repository\ContentTypeService */
     private $contentTypeService;
 
-    /** @var \Symfony\Component\Routing\RouterInterface */
-    private $router;
+    /** @var \Symfony\Component\Routing\Generator\UrlGeneratorInterface */
+    private $urlGenerator;
 
     public function __construct(
         ConfigResolverInterface $configResolver,
         FormFactoryInterface $formFactory,
         SectionService $sectionService,
         ContentTypeService $contentTypeService,
-        RouterInterface $router
+        UrlGeneratorInterface $urlGenerator
     ) {
         $this->configResolver = $configResolver;
         $this->formFactory = $formFactory;
         $this->sectionService = $sectionService;
         $this->contentTypeService = $contentTypeService;
-        $this->router = $router;
+        $this->urlGenerator = $urlGenerator;
     }
 
     public static function getSubscribedEvents()
@@ -116,7 +116,7 @@ class SearchViewFilter implements EventSubscriberInterface
             [
                 'method' => Request::METHOD_GET,
                 'csrf_protection' => false,
-                'action' => $this->router->generate('ezplatform.search'),
+                'action' => $this->urlGenerator->generate('ezplatform.search'),
             ]
         );
 


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       | https://issues.ibexa.co/browse/IBX-2
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | no
| Doc needed?   | yes
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-admin-ui/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->

It is now possible to render search form anywhere is needed with
`{{ render(controller('Ibexa\\Platform\\Bundle\\Search\\Controller\\SearchController::searchAction')) }}`, and be redirected to search results page.

https://github.com/ezsystems/ezplatform-admin-ui/pull/1719

#### Checklist:
- [x] Implement tests
- [x] Coding standards (`$ composer fix-cs`)
