### PR TITLE
IBX-1243: Fixed issue with missing translation for dropdown fields on the search

### DIFF
--- a/src/bundle/Form/Type/SearchType.php
+++ b/src/bundle/Form/Type/SearchType.php
@@ -90,6 +90,7 @@ final class SearchType extends AbstractType
     {
         $resolver->setDefaults([
             'data_class' => SearchData::class,
+            'translation_domain' => 'search',
         ]);
     }
 }

--- a/src/bundle/Resources/translations/search.en.xliff
+++ b/src/bundle/Resources/translations/search.en.xliff
@@ -61,6 +61,11 @@
         <target>Section</target>
         <note>key: search.section</note>
       </trans-unit>
+      <trans-unit id="03d6d5922fd2012e155e50306eaf98e2dfeb21c6" resname="search.section.any">
+        <source>Any section</source>
+        <target state="new">Any section</target>
+        <note>key: search.section.any</note>
+      </trans-unit>
       <trans-unit id="777cc1ef279096d5a978aa3553e9434d828f8248" resname="search.tips.check_spelling">
         <source>Check the spelling of keywords.</source>
         <target>Check the spelling of keywords.</target>


### PR DESCRIPTION
| Question      | Answer
| ------------- | ---
| Tickets       |  https://issues.ibexa.co/browse/IBX-1243
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Tests pass?   | yes
| Doc needed?   | no
| License       | [GPL-2.0](https://github.com/ezsystems/ezplatform-search/blob/master/LICENSE)
<!-- Keep in mind: Your contribution has to be compatible with GPL-2.0 as well: https://www.gnu.org/licenses/old-licenses/gpl-2.0-faq.html#GPLModuleLicense -->


The problem occurred due to a missing translation domain in the FormType class. Related PR https://github.com/ezsystems/ezplatform-admin-ui/pull/1967


#### Checklist:
- [x] Implement tests
- [x] Coding standards (`$ composer fix-cs`)
